### PR TITLE
fix(transform): check all console.error args in Fragment warning suppression

### DIFF
--- a/packages/domscribe-transform/src/plugins/turbopack/turbopack.loader.ts
+++ b/packages/domscribe-transform/src/plugins/turbopack/turbopack.loader.ts
@@ -156,7 +156,7 @@ function buildClientGlobalsPreamble(options: TurbopackLoaderOptions): string {
       `window.__DOMSCRIBE_CONSOLE_PATCHED__=true;` +
       `var _ce=console.error;` +
       `console.error=function(){` +
-      `if(typeof arguments[0]==='string'&&arguments[0].indexOf('data-ds')!==-1&&arguments[0].indexOf('React.Fragment')!==-1)return;` +
+      `if(typeof arguments[0]==='string'){var _s=Array.prototype.join.call(arguments,' ');if(_s.indexOf('data-ds')!==-1&&_s.indexOf('React.Fragment')!==-1)return}` +
       `return _ce.apply(console,arguments)` +
       `}}`,
   );

--- a/packages/domscribe-transform/src/plugins/vite/vite.plugin.ts
+++ b/packages/domscribe-transform/src/plugins/vite/vite.plugin.ts
@@ -315,7 +315,7 @@ export function domscribe(options: VitePluginOptions = {}): Plugin {
           `window.__DOMSCRIBE_CONSOLE_PATCHED__=true;` +
           `var _ce=console.error;` +
           `console.error=function(){` +
-          `if(typeof arguments[0]==='string'&&arguments[0].indexOf('data-ds')!==-1&&arguments[0].indexOf('React.Fragment')!==-1)return;` +
+          `if(typeof arguments[0]==='string'){var _s=Array.prototype.join.call(arguments,' ');if(_s.indexOf('data-ds')!==-1&&_s.indexOf('React.Fragment')!==-1)return}` +
           `return _ce.apply(console,arguments)` +
           `}}`,
         injectTo: 'head-prepend',

--- a/packages/domscribe-transform/src/plugins/webpack/webpack.plugin.ts
+++ b/packages/domscribe-transform/src/plugins/webpack/webpack.plugin.ts
@@ -277,7 +277,7 @@ export class DomscribeWebpackPlugin {
         `window.__DOMSCRIBE_CONSOLE_PATCHED__=true;` +
         `var _ce=console.error;` +
         `console.error=function(){` +
-        `if(typeof arguments[0]==='string'&&arguments[0].indexOf('data-ds')!==-1&&arguments[0].indexOf('React.Fragment')!==-1)return;` +
+        `if(typeof arguments[0]==='string'){var _s=Array.prototype.join.call(arguments,' ');if(_s.indexOf('data-ds')!==-1&&_s.indexOf('React.Fragment')!==-1)return}` +
         `return _ce.apply(console,arguments)` +
         `}}` +
         `</script>`,


### PR DESCRIPTION
## Summary

- React 18 calls `console.error` with a format string and separate arguments: `console.error('Invalid prop \`%s\` supplied to \`%s\`', 'data-ds', 'React.Fragment')`. The previous suppression only checked `arguments[0]` (the format string), which contains `%s` placeholders — not the actual prop name or component name — so the filter never matched.
- Fixed by joining all arguments into a single string before checking for `data-ds` and `React.Fragment`. Works for both React 18 (format string + args) and React 19 (pre-formatted string).
- Applied to all three plugin entry points: turbopack loader, vite plugin, webpack plugin.

## Test plan

- [ ] Build domscribe, install in a Next.js app using React 18 (e.g. cal.com), verify Fragment `data-ds` warnings no longer appear
- [ ] Verify no regressions with React 19 / Vite / standalone Webpack setups

🤖 Generated with [Claude Code](https://claude.com/claude-code)