### PR TITLE
fix(transform,react): lazy parser init and inline preamble for SSR

### DIFF
--- a/packages/domscribe-react/src/vite/vite-plugin.ts
+++ b/packages/domscribe-react/src/vite/vite-plugin.ts
@@ -44,6 +44,7 @@ const INIT_MODULE_PATH = '/@domscribe/react-init.js';
 export function domscribe(options?: DomscribeReactPluginOptions): Plugin {
   const basePlugin = baseDomscribe(options);
   const baseTransformIndexHtml = basePlugin.transformIndexHtml;
+  const baseTransform = basePlugin.transform;
   const baseResolveId =
     typeof basePlugin.resolveId === 'function' ? basePlugin.resolveId : null;
   const baseLoad =
@@ -94,6 +95,37 @@ export function domscribe(options?: DomscribeReactPluginOptions): Plugin {
       ].join('\n');
     }
     return baseLoad?.call(this, id, ...args) ?? null;
+  };
+
+  // Wrap the base transform hook to inject a React runtime init preamble.
+  // In SSR frameworks (e.g. React Router 7), transformIndexHtml may not fire,
+  // so we inject `import('/@domscribe/react-init.js')` into every transformed
+  // file, guarded by a `__DOMSCRIBE_REACT_INIT__` flag to run only once.
+  basePlugin.transform = async function (code, sourceFile) {
+    const baseTransformFn =
+      typeof baseTransform === 'function' ? baseTransform : undefined;
+    const baseResult = baseTransformFn
+      ? await baseTransformFn.call(this, code, sourceFile)
+      : null;
+
+    if (
+      !baseResult ||
+      typeof baseResult !== 'object' ||
+      !('code' in baseResult)
+    ) {
+      return baseResult;
+    }
+
+    const reactInitPreamble =
+      `if(typeof window!=='undefined'&&!window.__DOMSCRIBE_REACT_INIT__){` +
+      `window.__DOMSCRIBE_REACT_INIT__=true;` +
+      `import('${INIT_MODULE_PATH}').catch(function(){})` +
+      `}\n`;
+
+    return {
+      ...baseResult,
+      code: reactInitPreamble + baseResult.code,
+    };
   };
 
   basePlugin.transformIndexHtml = (): IndexHtmlTransformResult => {

--- a/packages/domscribe-react/src/vite/vite-plugin.ts
+++ b/packages/domscribe-react/src/vite/vite-plugin.ts
@@ -72,7 +72,9 @@ export function domscribe(options?: DomscribeReactPluginOptions): Plugin {
         : `const _resolvers = new Map();`;
 
       // Bare specifiers here get rewritten by Vite's transform pipeline
-      // to pre-bundled paths, matching what the overlay resolves internally
+      // to pre-bundled paths, matching what the overlay resolves internally.
+      // This module also handles overlay init as a fallback for SSR setups
+      // where transformIndexHtml doesn't fire (e.g. React Router 7).
       return [
         `import { RuntimeManager } from '@domscribe/runtime';`,
         `import { createReactAdapter } from '@domscribe/react';`,
@@ -92,6 +94,13 @@ export function domscribe(options?: DomscribeReactPluginOptions): Plugin {
         `    hookNameResolvers: _resolvers,`,
         `  }),`,
         `}).catch(e => console.warn('[domscribe] Failed to init React runtime:', e.message));`,
+        ``,
+        `// Init overlay if configured (SSR fallback — transformIndexHtml may not fire).`,
+        `// Uses bare specifier so Vite resolves to the same pre-bundled module instance`,
+        `// that RuntimeManager uses, ensuring singleton sharing.`,
+        `if (typeof window !== 'undefined' && window.__DOMSCRIBE_OVERLAY_OPTIONS__) {`,
+        `  import('@domscribe/overlay').then(m => m.initOverlay()).catch(() => {});`,
+        `}`,
       ].join('\n');
     }
     return baseLoad?.call(this, id, ...args) ?? null;

--- a/packages/domscribe-transform/src/core/injector-performance.bench.ts
+++ b/packages/domscribe-transform/src/core/injector-performance.bench.ts
@@ -91,7 +91,7 @@ async function measureTransformOverhead(
 
   for (const file of sourceFiles) {
     const ext = file.extension as InjectorFileExtension;
-    const injector = registry.getInjector(ext);
+    const injector = await registry.getInjector(ext);
 
     const start = performance.now();
     injector.inject(file.content, { sourceFile: file.path });

--- a/packages/domscribe-transform/src/core/injector.registry.ts
+++ b/packages/domscribe-transform/src/core/injector.registry.ts
@@ -4,6 +4,10 @@
  * Maps file extensions (jsx, tsx, vue) to their corresponding parser/injector
  * pairs. Singleton per workspace to share ID caches across transforms.
  *
+ * Parsers are created lazily on first access via `getInjector()` to avoid
+ * importing unnecessary parser dependencies (e.g. `vue/compiler-sfc` in
+ * React-only projects).
+ *
  * @module @domscribe/transform/core/injector-registry
  */
 import { createInjector, DomscribeInjector } from './injector.js';
@@ -35,18 +39,24 @@ export type InjectorFileExtension = keyof InjectorRegistryMap;
 /**
  * Registry of file-type-specific injectors.
  * Manages lifecycle (initialize, saveCache, close) for all injectors as a unit.
+ *
+ * Parsers are instantiated lazily — only when `getInjector()` is first called
+ * for a given file type. This avoids importing `vue/compiler-sfc` (or other
+ * framework-specific parsers) in projects that don't use them.
  */
 export class InjectorRegistry {
   private static instances: Map<string, InjectorRegistry> = new Map();
-  private registry: InjectorRegistryMap;
+  private readonly registry: Map<
+    InjectorFileExtension,
+    JSXInjector | TSXInjector | VueInjector
+  > = new Map();
   private isClosed = false;
+  private readonly workspaceRoot: string;
+  private readonly options: InjectorOptions | undefined;
 
   constructor(workspaceRoot: string, options?: InjectorOptions) {
-    this.registry = {
-      jsx: createInjector(new AcornParser(), workspaceRoot, options),
-      tsx: createInjector(new BabelParser(), workspaceRoot, options),
-      vue: createInjector(new VueSFCParser(), workspaceRoot, options),
-    };
+    this.workspaceRoot = workspaceRoot;
+    this.options = options;
   }
 
   /**
@@ -72,19 +82,24 @@ export class InjectorRegistry {
     return instance;
   }
 
-  /** Initialize all injectors in the registry. Safe to call multiple times. */
+  /**
+   * No-op — kept for API compatibility.
+   *
+   * @remarks
+   * Parsers are now initialized lazily in `getInjector()`. Existing call
+   * sites that await `initialize()` continue to work without changes.
+   */
   async initialize(): Promise<void> {
-    for (const injector of Object.values(this.registry)) {
-      await injector.initialize();
-    }
+    // Lazy initialization happens in getInjector()
   }
 
   /**
    * Persist all injector ID caches to disk without closing the registry.
    * Safe to call after every transform — only writes when dirty.
+   * Only operates on parsers that were actually created.
    */
   saveCache(): void {
-    for (const injector of Object.values(this.registry)) {
+    for (const injector of this.registry.values()) {
       injector.saveCache();
     }
   }
@@ -93,16 +108,55 @@ export class InjectorRegistry {
     // Mark as closed FIRST so getInstance() creates a fresh instance
     // even if an injector's close() throws.
     this.isClosed = true;
-    for (const injector of Object.values(this.registry)) {
+    for (const injector of this.registry.values()) {
       injector.close();
     }
   }
 
-  /** Get the injector for a specific file extension. */
-  getInjector(
+  /**
+   * Get the injector for a specific file extension.
+   * Creates and initializes the parser on first access for each type.
+   */
+  async getInjector(
+    type: InjectorFileExtension,
+  ): Promise<JSXInjector | TSXInjector | VueInjector> {
+    const existing = this.registry.get(type);
+    if (existing) {
+      return existing;
+    }
+
+    const injector = this.createInjector(type);
+    await injector.initialize();
+    this.registry.set(type, injector);
+    return injector;
+  }
+
+  /** Create an injector for the given file type using stored workspace config. */
+  private createInjector(
     type: InjectorFileExtension,
   ): JSXInjector | TSXInjector | VueInjector {
-    return this.registry[type];
+    // Use the factory pattern but with the actual workspace root and options
+    const factories = {
+      jsx: () =>
+        createInjector(
+          new AcornParser(),
+          this.workspaceRoot,
+          this.options,
+        ) as JSXInjector,
+      tsx: () =>
+        createInjector(
+          new BabelParser(),
+          this.workspaceRoot,
+          this.options,
+        ) as TSXInjector,
+      vue: () =>
+        createInjector(
+          new VueSFCParser(),
+          this.workspaceRoot,
+          this.options,
+        ) as VueInjector,
+    };
+    return factories[type]();
   }
 }
 

--- a/packages/domscribe-transform/src/core/injector.spec.ts
+++ b/packages/domscribe-transform/src/core/injector.spec.ts
@@ -7,6 +7,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import os from 'os';
+import path from 'path';
 import { DomscribeInjector, createInjector } from './injector.js';
 import {
   InjectorRegistry,
@@ -720,39 +722,39 @@ describe('Factory & Registry', () => {
   });
 
   describe('InjectorRegistry', () => {
-    it('should create jsx and tsx injectors via getInjector()', () => {
+    it('should create jsx and tsx injectors via getInjector()', async () => {
       // Arrange
-      const workspaceRoot = '/workspace/registry-test-1';
+      const workspaceRoot = path.join(os.tmpdir(), 'ds-registry-test-1');
 
       // Act
       const registry = InjectorRegistry.getInstance(workspaceRoot);
 
       // Assert
       expect(registry).toBeDefined();
-      expect(registry.getInjector('jsx')).toBeDefined();
-      expect(registry.getInjector('tsx')).toBeDefined();
+      expect(await registry.getInjector('jsx')).toBeDefined();
+      expect(await registry.getInjector('tsx')).toBeDefined();
     });
 
-    it('should use AcornParser for jsx', () => {
+    it('should use AcornParser for jsx', async () => {
       // Arrange
-      const workspaceRoot = '/workspace/registry-test-2';
+      const workspaceRoot = path.join(os.tmpdir(), 'ds-registry-test-2');
 
       // Act
       const registry = InjectorRegistry.getInstance(workspaceRoot);
-      const jsxInjector = registry.getInjector('jsx');
+      const jsxInjector = await registry.getInjector('jsx');
 
       // Assert
       expect(jsxInjector.getParser()).toBeDefined();
       expect(jsxInjector.getParser().constructor.name).toBe('AcornParser');
     });
 
-    it('should use BabelParser for tsx', () => {
+    it('should use BabelParser for tsx', async () => {
       // Arrange
-      const workspaceRoot = '/workspace/registry-test-3';
+      const workspaceRoot = path.join(os.tmpdir(), 'ds-registry-test-3');
 
       // Act
       const registry = InjectorRegistry.getInstance(workspaceRoot);
-      const tsxInjector = registry.getInjector('tsx');
+      const tsxInjector = await registry.getInjector('tsx');
 
       // Assert
       expect(tsxInjector.getParser()).toBeDefined();
@@ -761,7 +763,7 @@ describe('Factory & Registry', () => {
 
     it('should return same instance for same workspaceRoot', () => {
       // Arrange
-      const workspaceRoot = '/workspace/registry-test-4';
+      const workspaceRoot = path.join(os.tmpdir(), 'ds-registry-test-4');
 
       // Act
       const registry1 = InjectorRegistry.getInstance(workspaceRoot);

--- a/packages/domscribe-transform/src/plugins/turbopack/turbopack.loader.ts
+++ b/packages/domscribe-transform/src/plugins/turbopack/turbopack.loader.ts
@@ -317,7 +317,7 @@ async function transformWithInit(
     timings.sourceMapConsumerMs = performance.now() - smStart;
   }
 
-  const injector = injectorRegistry.getInjector(fileExtension);
+  const injector = await injectorRegistry.getInjector(fileExtension);
 
   let result;
   try {

--- a/packages/domscribe-transform/src/plugins/vite/vite.plugin.spec.ts
+++ b/packages/domscribe-transform/src/plugins/vite/vite.plugin.spec.ts
@@ -568,17 +568,12 @@ describe('domscribe Vite plugin', () => {
         sourceFile,
       );
 
-      // Assert
-      expect(result).toEqual({
-        code: 'transformed code',
-        map: {
-          version: 3,
-          sources: [],
-          names: [],
-          mappings: '',
-          file: 'original.tsx',
-        },
-      });
+      // Assert — preamble is prepended to the transformed code
+      expect(result).not.toBeNull();
+      expect(result).toHaveProperty('code');
+      expect(result).toHaveProperty('map');
+      expect((result as { code: string }).code).toContain('transformed code');
+      expect((result as { code: string }).code).toContain('typeof window');
     });
 
     it('should transform matching TSX files', async () => {
@@ -618,7 +613,7 @@ describe('domscribe Vite plugin', () => {
       expect(result).not.toBeNull();
       expect(result).toHaveProperty('code');
       if (typeof result === 'object') {
-        expect(result?.code).toBe('transformed tsx code');
+        expect(result?.code).toContain('transformed tsx code');
       }
     });
 
@@ -827,11 +822,12 @@ describe('domscribe Vite plugin', () => {
         '/test/App.jsx',
       );
 
-      // Assert
-      expect(result).toEqual({
-        code: 'transformed with map',
-        map: expectedMap,
-      });
+      // Assert — preamble is prepended to code
+      expect(result).not.toBeNull();
+      expect((result as { code: string }).code).toContain(
+        'transformed with map',
+      );
+      expect((result as { map: unknown }).map).toEqual(expectedMap);
     });
   });
 
@@ -1157,15 +1153,14 @@ describe('domscribe Vite plugin', () => {
         },
       );
       expect(mockSourceMapConsumer.destroy).toHaveBeenCalled();
-      expect(result).toEqual({
-        code: 'transformed code',
-        map: {
-          version: 3,
-          sources: ['App.jsx'],
-          names: [],
-          mappings: 'AAAA',
-          file: 'App.jsx',
-        },
+      expect(result).not.toBeNull();
+      expect((result as { code: string }).code).toContain('transformed code');
+      expect((result as { map: unknown }).map).toEqual({
+        version: 3,
+        sources: ['App.jsx'],
+        names: [],
+        mappings: 'AAAA',
+        file: 'App.jsx',
       });
     });
 
@@ -1248,16 +1243,15 @@ describe('domscribe Vite plugin', () => {
         '/test/Empty.jsx',
       );
 
-      // Assert
-      expect(result).toEqual({
-        code: '',
-        map: {
-          version: 3,
-          sources: [],
-          names: [],
-          mappings: '',
-          file: 'Empty.jsx',
-        },
+      // Assert — preamble is still prepended even for empty transformed code
+      expect(result).not.toBeNull();
+      expect((result as { code: string }).code).toContain('typeof window');
+      expect((result as { map: unknown }).map).toEqual({
+        version: 3,
+        sources: [],
+        names: [],
+        mappings: '',
+        file: 'Empty.jsx',
       });
     });
   });

--- a/packages/domscribe-transform/src/plugins/vite/vite.plugin.ts
+++ b/packages/domscribe-transform/src/plugins/vite/vite.plugin.ts
@@ -24,6 +24,71 @@ import {
 import { RelayControl } from '@domscribe/relay';
 
 /**
+ * Build a JS preamble that sets relay + overlay globals on `window`.
+ *
+ * Injected into every transformed file so that SSR frameworks (e.g. React
+ * Router 7 SSR) that bypass Vite's `transformIndexHtml` pipeline still
+ * get the window globals needed for overlay initialization.
+ *
+ * Safe for non-SSR too — window property assignments are idempotent, and
+ * the entire block is guarded by `typeof window !== 'undefined'`.
+ */
+function buildVitePreamble(opts: {
+  relayPort: number | undefined;
+  relayHost: string | undefined;
+  overlayEnabled: boolean;
+  overlayOptions: OverlayPluginOptions;
+  debug: boolean;
+}): string {
+  const parts: string[] = [];
+
+  // Suppress React Fragment prop warning for data-ds (once per page load)
+  parts.push(
+    `if(!window.__DOMSCRIBE_CONSOLE_PATCHED__){` +
+      `window.__DOMSCRIBE_CONSOLE_PATCHED__=true;` +
+      `var _ce=console.error;` +
+      `console.error=function(){` +
+      `if(typeof arguments[0]==='string'){var _s=Array.prototype.join.call(arguments,' ');if(_s.indexOf('data-ds')!==-1&&_s.indexOf('React.Fragment')!==-1)return}` +
+      `return _ce.apply(console,arguments)` +
+      `}}`,
+  );
+
+  if (opts.relayPort !== undefined) {
+    parts.push(`window.__DOMSCRIBE_RELAY_PORT__=${opts.relayPort}`);
+  }
+  if (opts.relayHost !== undefined) {
+    parts.push(
+      `window.__DOMSCRIBE_RELAY_HOST__=${JSON.stringify(opts.relayHost)}`,
+    );
+  }
+
+  if (opts.overlayEnabled && opts.relayPort !== undefined) {
+    const overlayOptionsObj = {
+      initialMode: opts.overlayOptions.initialMode ?? 'collapsed',
+      debug: opts.overlayOptions.debug ?? opts.debug,
+    };
+    parts.push(
+      `window.__DOMSCRIBE_OVERLAY_OPTIONS__=${JSON.stringify(overlayOptionsObj)}`,
+    );
+  }
+
+  // Auto-init overlay (once per page load) for SSR scenarios where
+  // transformIndexHtml never fires
+  let autoInit = '';
+  if (opts.overlayEnabled && opts.relayPort !== undefined) {
+    autoInit =
+      `if(!window.__DOMSCRIBE_AUTO_INIT__){` +
+      `window.__DOMSCRIBE_AUTO_INIT__=true;` +
+      `import('/node_modules/@domscribe/overlay/index.js').then(function(m){return m.initOverlay()}).catch(function(){})` +
+      `}`;
+  }
+
+  return (
+    `if(typeof window!=='undefined'){${parts.join(';')};` + autoInit + `}\n`
+  );
+}
+
+/**
  * Create the Domscribe Vite plugin.
  *
  * @param options - Plugin configuration (file filters, debug, relay, overlay)
@@ -216,7 +281,7 @@ export function domscribe(options: VitePluginOptions = {}): Plugin {
           return null;
         }
 
-        const injector = injectorRegistry.getInjector(fileExtension);
+        const injector = await injectorRegistry.getInjector(fileExtension);
 
         // Inject data-ds attributes and generate manifest entries
         const {
@@ -269,8 +334,22 @@ export function domscribe(options: VitePluginOptions = {}): Plugin {
         // Schedule transforms settled check after transform settles
         scheduleTransformsSettledCheck();
 
+        // Prepend relay/overlay globals into every transformed file.
+        // This ensures SSR frameworks (e.g. React Router 7) that bypass
+        // Vite's transformIndexHtml pipeline still get the window globals.
+        // The preamble is guarded by `typeof window !== 'undefined'` and
+        // all assignments are idempotent, so it's safe for non-SSR too.
+        const preamble = buildVitePreamble({
+          relayPort,
+          relayHost,
+          overlayEnabled,
+          overlayOptions,
+          debug,
+        });
+        const outputCode = preamble + transformedCode;
+
         return {
-          code: transformedCode,
+          code: outputCode,
           map,
         };
       } catch (error) {

--- a/packages/domscribe-transform/src/plugins/vite/vite.plugin.ts
+++ b/packages/domscribe-transform/src/plugins/vite/vite.plugin.ts
@@ -72,20 +72,14 @@ function buildVitePreamble(opts: {
     );
   }
 
-  // Auto-init overlay (once per page load) for SSR scenarios where
-  // transformIndexHtml never fires
-  let autoInit = '';
-  if (opts.overlayEnabled && opts.relayPort !== undefined) {
-    autoInit =
-      `if(!window.__DOMSCRIBE_AUTO_INIT__){` +
-      `window.__DOMSCRIBE_AUTO_INIT__=true;` +
-      `import('/node_modules/@domscribe/overlay/index.js').then(function(m){return m.initOverlay()}).catch(function(){})` +
-      `}`;
-  }
+  // Overlay auto-init is NOT done here — it's handled by:
+  //   • transformIndexHtml (SPA setups)
+  //   • Framework adapter virtual modules (SSR setups, e.g. react-init.js)
+  // Importing the overlay from the preamble via /node_modules/ path creates
+  // a separate module instance from Vite's pre-bundled version, which breaks
+  // RuntimeManager singleton sharing with the adapter.
 
-  return (
-    `if(typeof window!=='undefined'){${parts.join(';')};` + autoInit + `}\n`
-  );
+  return `if(typeof window!=='undefined'){${parts.join(';')}}\n`;
 }
 
 /**

--- a/packages/domscribe-transform/src/plugins/webpack/webpack.loader.ts
+++ b/packages/domscribe-transform/src/plugins/webpack/webpack.loader.ts
@@ -113,7 +113,7 @@ export async function transform(
     timings.sourceMapConsumerMs = performance.now() - smStart;
   }
 
-  const injector = injectorRegistry.getInjector(fileExtension);
+  const injector = await injectorRegistry.getInjector(fileExtension);
 
   // Inject data-ds attributes and generate manifest entries
   let result;


### PR DESCRIPTION
## Summary

- **Lazy parser initialization** — `InjectorRegistry` no longer eagerly creates all 3 parsers (Acorn, Babel, Vue) in its constructor. Parsers are instantiated and initialized on-demand when `getInjector()` is first called for a file type. React-only projects will never load `vue/compiler-sfc`, eliminating the spurious warning.
- **Inline preamble injection for SSR** — The Vite plugin now injects relay/overlay window globals (`__DOMSCRIBE_RELAY_PORT__`, etc.) directly into every transformed file via a guarded preamble, modeled after the turbopack-loader's `buildClientGlobalsPreamble()`. This ensures SSR frameworks (React Router 7, Remix) that bypass Vite's `transformIndexHtml` still get the overlay. `transformIndexHtml` is kept as-is for SPA setups.
- **React plugin SSR fallback** — The React Vite plugin wraps the base `transform` hook to also inject `import('/@domscribe/react-init.js')`, ensuring RuntimeManager + ReactAdapter initialize even when `transformIndexHtml` doesn't fire.

Closes #19, closes #20

## Test plan

- [x] `nx test domscribe-transform` — all 365 tests pass
- [x] `nx build domscribe-transform` — clean
- [x] `nx build domscribe-react` — clean
- [x] `nx typecheck domscribe-transform` — clean
- [x] `nx typecheck domscribe-react` — clean
- [ ] Manual: React SPA (Vite) — overlay still works via `transformIndexHtml` (no regression)
- [ ] Manual: React-only project — no Vue warning in console
- [ ] Manual: Vue project — Vue parser still works when `.vue` files are encountered