### PR TITLE
fix: use "./" as plugin source path (schema compliance)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "domscribe",
       "description": "Domscribe is a pixel-to-code development tool that maps running UI elements to their exact source locations, capturing runtime context (props, state, DOM) for handoff to coding agents via MCP.",
-      "source": ".",
+      "source": "./",
       "homepage": "https://github.com/patchorbit/domscribe",
       "repository": "https://github.com/patchorbit/domscribe",
       "license": "MIT",


### PR DESCRIPTION
## Summary

`.claude-plugin/marketplace.json` currently declares the plugin's `source` as `"."`. Claude Code's plugin marketplace schema rejects this as invalid; the relative-directory-reference form it expects is `"./"`. The one-character fix here unblocks adding the marketplace via `directory` sources and (I suspect, haven't tested) `github` sources too.

## Reproduction

When installing this marketplace locally (via `extraKnownMarketplaces` with a `directory` source pointing at a clone of this repo), Claude Code errors out on the `"."` source and won't register the plugin.

## Fix

Change `"source": "."` → `"source": "./"` in `.claude-plugin/marketplace.json`. No other changes.

Happy to rework if you prefer a different pattern — just wanted to flag the schema issue and propose the minimum-risk fix.