### PR TITLE
feat(benchmark): scaffold Code→UI Benchmark comparators (chrome-devtools-mcp + WebMCP reference) and /benchmark v1 results page

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Click any element in the browser overlay, describe the change in plain English, 
 - 📁 **Annotations live in your repo** — stored as JSON files in `.domscribe/annotations/`, exposed via REST APIs that MCP wraps for agent access
 - 📡 **Real-time feedback** — WebSocket relay pushes agent responses to the browser overlay as they happen
 
+### Code→UI Benchmark
+
+We score five source-mapped scenarios (S1 source-position query, S2 style provenance with source, S3 multi-instance enumeration, S4 runtime context probe, S5 annotation→source roundtrip) across three fixtures (Vite/React, Nuxt/Vue, Next.js) and three MCP comparators (RCP v1, `chrome-devtools-mcp`, an in-repo WebMCP-conformant reference). See **[Code→UI Benchmark v1 results](./docs/code-to-ui-benchmark/v1-results.md)** for the 45-cell table, methodology, and reproduction command.
+
 ---
 
 ## Manual Setup

--- a/TECHNICAL_SPEC.md
+++ b/TECHNICAL_SPEC.md
@@ -1186,6 +1186,10 @@ Nx Task Runner (controls fixture-level parallelism)
 | Vue       | 3.3+    | Webpack 5           | Yes             | VNode                       | Full   |
 | Vue       | 3.3+    | Nuxt 3              | Yes             | VNode                       | Full   |
 
+### Code→UI Benchmark
+
+The Code→UI Benchmark v1 scores Domscribe's RCP-v1 surface against `chrome-devtools-mcp` and an in-repo WebMCP-conformant reference across five source-mapped scenarios (S1–S5) and three fixtures (Vite/React, Nuxt/Vue, Next.js) — 45 cells in total. See [`docs/code-to-ui-benchmark/v1-results.md`](./docs/code-to-ui-benchmark/v1-results.md) for the public results page, methodology, and reproduction command. The comparator implementations live in [`packages/domscribe-benchmark-comparators/`](./packages/domscribe-benchmark-comparators/README.md); the benchmark spec and runner live in `@domscribe/benchmark`.
+
 ---
 
 ## 10. CI/CD Pipeline

--- a/docs/code-to-ui-benchmark/v1-results.md
+++ b/docs/code-to-ui-benchmark/v1-results.md
@@ -1,0 +1,71 @@
+# Code→UI Benchmark v1 — Results
+
+**Spec:** [`v1.md`](./v1.md) (sprint 2613 — landed by Task A)
+**Suite:** `@domscribe/benchmark@1.0.0`
+**Comparators:** [`@domscribe/benchmark-comparators`](../../packages/domscribe-benchmark-comparators/README.md)
+
+This page hosts the public 45-cell results table for the Code→UI Benchmark. The benchmark measures five source-mapped scenarios (S1–S5) across three fixtures (Vite/React, Nuxt/Vue, Next.js) and three MCP comparators (RCP v1, chrome-devtools-mcp, in-repo WebMCP-conformant reference).
+
+> [!NOTE]
+> Last-run timestamp, comparator versions, and the 45-cell results table are populated by the runner in `@domscribe/benchmark` (sprint 2613 Task A). This document is the scaffold; the results below are placeholders until the runner produces `results.json` and the page is regenerated. The placeholders are intentional and unambiguous — empty cells get a literal `—`, not a value.
+
+## Reproduce this
+
+```bash
+git clone https://github.com/patchorbit/domscribe.git
+cd domscribe
+pnpm install
+pnpm nx test domscribe-benchmark
+# Runner writes results.json next to this page; re-render with:
+pnpm nx run domscribe-benchmark:render-results
+```
+
+## Comparators
+
+| Name                  | External validity | Version                                         | Notes                                                                                                                            |
+| --------------------- | ----------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `rcp-v1`              | Subject           | (RCP v1 spec, [`docs/rcp/v1.md`](../rcp/v1.md)) | The artifact under measurement; RCP v1 is documentation-versioned per RFC 0003                                                   |
+| `chrome-devtools-mcp` | External          | `1.1.1` (pinned in root `package.json`)         | Generic runtime browser-MCP; no build-time source correlation                                                                    |
+| `webmcp-reference`    | In-repo fallback  | `0.1.0-in-repo-reference`                       | Minimal WebMCP-conformant reference per RFC 0004 fallback; replace with external WebMCP server when one is installable in-sprint |
+
+### Why one column is an in-repo reference
+
+The benchmark would prefer three external comparators. As of sprint 2613 there is no public WebMCP-conformant server that installs cleanly on a clean clone — the in-repo reference exists so the third column is reproducible. It is, by definition, a comparison where we wrote both sides; that caveat is recorded here and on the column header in the results table. Replacing the reference with a real external server is the structural fix and is tracked as a follow-on.
+
+## Results
+
+> **Status:** Pending Task A's runner. The table below is the schema-true placeholder; cells are populated by `results.json` at runner-completion time.
+
+| Scenario                        | Fixture | `rcp-v1` | `chrome-devtools-mcp` | `webmcp-reference` |
+| ------------------------------- | ------- | -------- | --------------------- | ------------------ |
+| S1 source-position query        | Vite    | —        | —                     | —                  |
+| S1 source-position query        | Nuxt    | —        | —                     | —                  |
+| S1 source-position query        | Next    | —        | —                     | —                  |
+| S2 style provenance with source | Vite    | —        | —                     | —                  |
+| S2 style provenance with source | Nuxt    | —        | —                     | —                  |
+| S2 style provenance with source | Next    | —        | —                     | —                  |
+| S3 multi-instance enumeration   | Vite    | —        | —                     | —                  |
+| S3 multi-instance enumeration   | Nuxt    | —        | —                     | —                  |
+| S3 multi-instance enumeration   | Next    | —        | —                     | —                  |
+| S4 runtime context probe        | Vite    | —        | —                     | —                  |
+| S4 runtime context probe        | Nuxt    | —        | —                     | —                  |
+| S4 runtime context probe        | Next    | —        | —                     | —                  |
+| S5 annotation→source roundtrip  | Vite    | —        | —                     | —                  |
+| S5 annotation→source roundtrip  | Nuxt    | —        | —                     | —                  |
+| S5 annotation→source roundtrip  | Next    | —        | —                     | —                  |
+
+**Cell legend:** `pass` (answered correctly per the binary rubric in v1.md), `refused` (tool reported it does not implement the surface), `wrong` (answered incorrectly), `—` (not yet run).
+
+## Methodology
+
+Each comparator implements a single `Comparator` interface (see [`packages/domscribe-benchmark-comparators/src/types/`](../../packages/domscribe-benchmark-comparators/src/types/index.ts)) and is invoked by the runner with a `ScenarioPrompt`. The binary rubric for each scenario (what counts as `pass`) is defined in `v1.md`. No tool gets credit for partial answers; refusal is a recorded outcome, not a missing value.
+
+The fixtures expose components at known source positions documented per fixture in `packages/domscribe-test-fixtures/fixtures/*/README.md`. Source-position changes to fixture components are gated by the same `protocol:freeze-check` CI gate that guards RCP v1, extended in sprint 2613 to fire on benchmark-spec edits without runner updates.
+
+## Falsifier
+
+Engineering portion (sprint 2613 close, 2026-07-10): all 45 cells populated by a reproducible runner; this page linked from `README.md` and `TECHNICAL_SPEC.md`. Adoption portion (sprint 2614 close, 2026-08-07): one of — a third-party public artifact names "Code→UI" or "runtime-context protocol" as Domscribe's category descriptor; an OSS reference-integration PR cites a benchmark scenario by ID; an external repo forks `@domscribe/benchmark` to run their own scoring. See [RFC 0004](../rfcs/0004-code-to-ui-benchmark-v1.md) for the full falsifier and retreat path.
+
+## Visual editors (qualitative)
+
+Cursor Visual Editor, Stagewise, and similar click-driven UI tools are out of the scoring table by design — they have no programmatic query surface and comparing MCP returns to human clicks is not a reproducible comparison. The category-level note: visual editors solve UI→Code (point and tell) without source-correlation guarantees; the Code→UI direction (an agent querying a running app) is the surface this benchmark measures. The [README](../../README.md#features) describes both directions.

--- a/docs/code-to-ui-benchmark/vendor-submission-amendment-plan.md
+++ b/docs/code-to-ui-benchmark/vendor-submission-amendment-plan.md
@@ -1,0 +1,42 @@
+# Code→UI Benchmark — Sprint 2612 vendor-submission amendment plan
+
+**Owner:** staff-swe-4 (sprint 2613 Task B)
+**Trigger to execute:** `docs/code-to-ui-benchmark/v1-results.md` is live and populated by Task A's runner with non-placeholder results.
+
+## Why this exists
+
+Sprint 2612 (PE [RFC 0003](../rfcs/0003-documentation-versioned-rcp-v1.md) / [sprint 2492 plan](../sprints/2492.md)) commits to filing four IDE-vendor-directory submissions (Cursor MCP / Cline / Continue / Codex) and one Cursor forum reply. The Code→UI Benchmark page is a category-level credibility surface that strengthens every one of those submissions — but only if it's amended in while the review windows are still open. This document is the checklist Task B's owner runs at the moment the results page goes live.
+
+## Current state (as of sprint 2613 kickoff, 2026-06-26)
+
+| Sprint 2612 deliverable                     | Expected location     | State on `main` | Amendable?                   |
+| ------------------------------------------- | --------------------- | --------------- | ---------------------------- |
+| `docs/submissions.md` (submission tracker)  | `docs/submissions.md` | **Missing**     | Depends on sprint 2612 close |
+| `docs/install/<channel>.json` × 8           | `docs/install/`       | **Missing**     | Depends on sprint 2612 close |
+| `docs/posts/2026-06-cursor-forum-146166.md` | `docs/posts/`         | **Missing**     | Depends on sprint 2612 close |
+| Cursor MCP directory PR                     | external repo         | Not filed       | Once filed                   |
+| Cline directory PR                          | external repo         | Not filed       | Once filed                   |
+| Continue directory PR                       | external repo         | Not filed       | Once filed                   |
+| Codex directory PR                          | external repo         | Not filed       | Once filed                   |
+
+**Implication:** Sprint 2612's vendor-submission deliverables have not landed on `main` as of sprint 2613 kickoff. The amendment plan below is the procedure to execute the moment they do. If sprint 2612 closes without those deliverables landing, the amendment scope changes from "amend existing submissions" to "include the benchmark link from the first submission" and the surface is even simpler.
+
+## Amendment procedure
+
+For each Sprint 2612 submission that is still in review (per `docs/submissions.md` review-status column) when this PR's [`v1-results.md`](./v1-results.md) is populated:
+
+1. **Read the submission's review status** in `docs/submissions.md`. If it is `merged` or `closed`, skip to step 4.
+2. **Push an addendum commit** to the submission PR adding the `/benchmark` link to the README/description section of the directory entry. Use this language verbatim so the four submissions converge on the same category descriptor:
+
+   > Domscribe is the Code→UI category — runtime-context queries from a coding agent to a running browser, source-correlated by the build-time RCP v1 protocol. See [Code→UI Benchmark v1 results](https://github.com/patchorbit/domscribe/blob/main/docs/code-to-ui-benchmark/v1-results.md) for a 45-cell scoring against `chrome-devtools-mcp` and a WebMCP-conformant reference across React, Vue, and Next.js fixtures.
+
+3. **Update `docs/submissions.md`** with a row noting the amendment date and the commit SHA of the addendum.
+4. **For submissions whose review window is closed** (no longer accepting commits), add a one-line entry to [`docs/sprints/2613.md`](../sprints/2613.md) under the "Sprint 2612 submission amendments — could not amend" section, naming the directory and the close reason.
+
+## Cursor forum reply (sprint 2612 T9)
+
+If the forum reply at [`forum.cursor.com/t/146166`](https://forum.cursor.com/t/click-to-source-from-browser-visual-editor-inspect-open-file-line/146166) is posted but the thread is still active, post a one-paragraph follow-up linking to `/benchmark` (do not edit the original — Cursor's forum etiquette favors transparent threading over silent edits). If the thread has gone cold (no replies in 7+ days at the moment this amendment is executed), do not bump it — surface to Kaushik instead.
+
+## Cutoff for executing this plan
+
+Per [RFC 0004 falsifier](../rfcs/0004-code-to-ui-benchmark-v1.md): by **2026-07-10 sprint 2613 close**. After that date the engineering window is closed and any unexecuted amendments are deferred to the sprint 2614 retro decision.

--- a/docs/sprints/2492.md
+++ b/docs/sprints/2492.md
@@ -1,0 +1,99 @@
+# Sprint 2492 — Domscribe
+
+**Window:** 2026-06-12 → 2026-06-26 (2 weeks)
+**Author:** pm-1 (PM persona)
+**Milestone:** [Sprint 2492 (#6)](https://github.com/patchorbit/domscribe/milestone/6)
+**Inputs:** DOP memo (sprint 2492), PE [RFC 0003](../rfcs/0003-documentation-versioned-rcp-v1.md), carried-forward `rcp`-labelled issues #33 #34 #35 #38 #39 from sprint 2491.
+
+## Sprint thesis
+
+Ship **RCP v1.0** as a documentation-versioned spec against `@domscribe/core` schemas, flip `@domscribe/mcp@1.0.0` to a public install path, and file all four IDE-vendor-directory submissions plus the PR-reviewed Cursor forum reply — within the sprint window that Chrome 146's WebMCP launch and the Cursor forum thread are still warm.
+
+## Why this thesis
+
+DOP's sprint 2492 memo reroutes capacity from `@domscribe/protocol` package extraction to IDE-vendor adoption (Cursor MCP directory, Cline/Continue/Codex marketplaces, forum reply). PE RFC 0003 amends RFC 0001's Alt A rejection and supersedes RFC 0002's commitment #2: ship v1 against current `@domscribe/core` schemas, defer the package extraction to a trigger-driven follow-on (#32), and substitute a `protocol:freeze-check` CI gate for the package boundary. PE also surfaces a one-line publish-blocker — `packages/domscribe-mcp/package.json` has `publishConfig.access = restricted` while every advertised IDE config tells users to `npx -y @domscribe/mcp` — and sequences the sprint around fixing that first. This thesis is DOP's bet (vendor adoption) + PE's sequencing constraint (install path must be real before submissions go out). Sprint 2491's drafts (#40 publish prep, #41 docs, #42 telemetry Worker) are work-banked and rolled forward.
+
+## Capacity
+
+- 2 staff-swe copies × 40h/sprint = **80h total**
+- Plan: ~37h (A) + ~36h (B) = **~73h (91% of capacity)**. Tight ceiling — 7h slack. Mitigated by ~10h of carried-forward draft work in #40 / #41 / #42.
+
+## Prioritization framework
+
+**Theory of Constraints,** same as sprint 2491. The bottleneck is dependency-driven, not effort-driven: the install path (`publishConfig` flip + freeze gate) is the new trunk that every vendor submission depends on, and the vendor submissions are the artifact the DOP falsifier reads. ToC sequences correctly — protect the trunk, then unblock the bet. RICE would mis-rank: the publishConfig flip has trivial "effort" and devastating "impact when missing," which collapses RICE's information content; ToC names the dependency explicitly.
+
+## Plan
+
+The walker hard-caps the fanout at 2 staff-swe tasks. Each task below is one engineer's sprint, bundling issues whose work shares files / subsystems / serial dependencies.
+
+### Task A — staff-swe-1: RCP v1.0 publish-readiness trunk (~37h)
+
+| ID  | Issue                                                                                                           | Priority | Effort | Acceptance                                                                                                                                                                      |
+| --- | --------------------------------------------------------------------------------------------------------------- | -------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T1  | [#44](https://github.com/patchorbit/domscribe/issues/44) — publishConfig flip + protocol-freeze CI gate         | P0       | 5h     | `publishConfig.access: public` verified via `npm pack`; `pnpm protocol:freeze-check` exists + wired into PR CI; a wire-schema edit without `docs/rcp/v1.md` change turns CI red |
+| T2  | [#33](https://github.com/patchorbit/domscribe/issues/33) — Normalize MCP tool names (snake_case + dotted alias) | P0       | 12h    | Aliases registered at SDK layer, deprecation log on alias hit, Windsurf regex passes, all advertised configs / skills / TECHNICAL_SPEC updated                                  |
+| T3  | [#38](https://github.com/patchorbit/domscribe/issues/38) — SourcePosition required on resolve*/query* outputs   | P0       | 10h    | Schemas reject responses missing `source_position`; relay emits valid `SourcePosition` in all integration tests                                                                 |
+| T4  | [#35](https://github.com/patchorbit/domscribe/issues/35) — Publish `docs/rcp/v1.md` + stability policy          | P0       | 6h     | Doc renders, stability policy falsifiable, linked from README + TECHNICAL_SPEC; RFC 0001 status → Accepted; reused as the freeze-check oracle (T1)                              |
+| T5  | [#39](https://github.com/patchorbit/domscribe/issues/39) — Publish `@domscribe/mcp@1.0.0` + tag RCP v1.0        | P0       | 4h     | Resolvable on npm public; `npx -y @domscribe/mcp` clean on a non-author machine; telemetry endpoint logs ≥1 session from verification install; release post Kaushik-signed      |
+
+**Task A total: 37h.** Sequence: T1 day 1 → T2/T3 in parallel (different surfaces) → T4 once T2/T3 settle their wire-schema diffs → T5 last. **T1 must merge by day 3 (2026-06-15)** or the freeze gate cannot guard T2/T3's wire-schema edits and the documentation-versioning argument loses its CI tripwire mid-sprint.
+
+### Task B — staff-swe-2: Telemetry + vendor-adoption motion (~36h)
+
+| ID  | Issue                                                                                                                                                              | Priority | Effort | Acceptance                                                                                                                                                                                                           |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| T6  | [#34](https://github.com/patchorbit/domscribe/issues/34) — Opt-in telemetry (infra + client; resumes draft [#42](https://github.com/patchorbit/domscribe/pull/42)) | P0       | 14h    | Worker deployed + KV namespace provisioned; default-off opt-in flag in `.domscribe/config.json`; `npx domscribe init` shows exact payload inline; integration test confirms no network call when flag false          |
+| T7  | [#45](https://github.com/patchorbit/domscribe/issues/45) — Vendor packaging metadata + install snippets (Cursor/Cline/Continue/Codex)                              | P0       | 6h     | Canonical `docs/install/<channel>.json` for all 8 channels; ≤140-char description matching substrate framing; README / TECHNICAL_SPEC / skills / gemini-extension reference docs/install/ rather than embedding copy |
+| T8  | [#46](https://github.com/patchorbit/domscribe/issues/46) — File 4 vendor-directory submissions                                                                     | P0       | 10h    | 4 submission PRs filed against Cursor MCP / Cline / Continue / Codex directory repos; `docs/submissions.md` tracks each with date + link + review status; Kaushik signed off on positioning blurbs                   |
+| T9  | [#47](https://github.com/patchorbit/domscribe/issues/47) — Cursor forum reply on `/t/146166` (PR-reviewed publishable artifact)                                    | P0       | 6h     | `docs/posts/2026-06-cursor-forum-146166.md` PR-reviewed; install snippet copy-paste tested against current Cursor; post live on forum thread; link captured in `docs/submissions.md`                                 |
+
+**Task B total: 36h.** Sequence: T6 day 1–8 (parallel to Task A trunk; independent surface) → T7 day 5–8 (begins as soon as `@domscribe/mcp` install path is real and canonical tool-name surface from T2 is settled) → **T5 (Task A) must publish before T8/T9 start** — submissions and forum reply both point at the published package. T8 + T9 land in days 9–14.
+
+### PR triage (Batch C — either engineer, light-touch, ~3h)
+
+| PR                                                                                   | Disposition                                                                                                                                                                         | Effort |
+| ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| [#43 vitest bump](https://github.com/patchorbit/domscribe/pull/43)                   | Merge if CI green (dependabot, low risk)                                                                                                                                            | 0.5h   |
+| [#42 telemetry Worker (draft)](https://github.com/patchorbit/domscribe/pull/42)      | Resumed by staff-swe-2 as part of T6; close + reopen at sprint close if necessary                                                                                                   | 0h     |
+| [#41 docs/rcp/v1.md (draft)](https://github.com/patchorbit/domscribe/pull/41)        | Resumed by staff-swe-1 as part of T4                                                                                                                                                | 0h     |
+| [#40 protocol publish prep (draft)](https://github.com/patchorbit/domscribe/pull/40) | **Re-scope** — original target was `@domscribe/protocol@1.0.0` (deferred per RFC 0003). Either repurpose for `@domscribe/mcp@1.0.0` publish artifacts (T5) or close + open fresh PR | 1h     |
+| [#37 ws bump](https://github.com/patchorbit/domscribe/pull/37)                       | Merge if CI green (dependabot, low risk)                                                                                                                                            | 0.5h   |
+| [#26 vite-dev bump](https://github.com/patchorbit/domscribe/pull/26)                 | Merge if CI green (dependabot, low risk)                                                                                                                                            | 0.5h   |
+| [#16 happy-dom bump](https://github.com/patchorbit/domscribe/pull/16)                | Recreate — 2 months stale, major-version dev dep; recommend dependabot re-runs                                                                                                      | 0.5h   |
+| [#30 MseeP.ai badge](https://github.com/patchorbit/domscribe/pull/30)                | Recommend Kaushik close as won't-fix — third-party promotional badge, off-positioning for serious build-time tool. PM does not close PRs it didn't author                           | 0h     |
+
+## Deferred
+
+- **[#32 Extract `@domscribe/protocol` package](https://github.com/patchorbit/domscribe/issues/32)** — deferred per PE RFC 0003 to a trigger-driven follow-on. Re-activates when either (a) ≥1 non-author npm package declares `@domscribe/core` as a wire-schema dependency, or (b) ≥10 weekly-active relay sessions via opt-in telemetry. The substitution is the `protocol:freeze-check` CI gate in T1.
+- **FrameworkAdapter public SDK** — DOP/RFC 0001 explicit deferral; concentrates surface area at the wrong layer this sprint.
+- **Svelte / Astro adapters** — DOP memo opportunity cost; vendor energy first.
+- **Domscribe Cloud / hosted SaaS** — DOP explicit rejection (Vercel/Linear/Replit house advantage).
+- **Transport-neutral RCP bindings (gRPC/JSON-RPC)** — RFC 0001 prior rejection; sprint 2492 does not change the calculus.
+- **`docs/architecture.md` seven-decisions doc** — RFC 0001 follow-on; RFCs remain canonical record.
+- **Outreach to directory maintainers for expedited review** — out-of-scope per #46 acceptance; if a submission is stuck >5 business days, surface to Kaushik (separate decision).
+
+## Won't-fix
+
+- **None recommended this sprint.** PR #30 (MseeP.ai badge) remains recommended-for-Kaushik-close — PM does not close PRs it didn't author. No other open issues warrant won't-fix classification given the sprint thesis is single-focus and the rest of the backlog is sleeping.
+
+## Plan falsifier
+
+By 2026-06-26 sprint close, **all of:** (a) `@domscribe/mcp@1.0.0` published with `access: public` and `npx -y @domscribe/mcp` verified working from a non-author install (T1 + T5); (b) RCP v1.0 tag stamped with snake_case canonical names + `SourcePosition` required + `docs/rcp/v1.md` live + `protocol:freeze-check` CI gate green (T2 + T3 + T4); (c) all four vendor-directory submissions filed and the `forum.cursor.com/t/146166` reply PR-reviewed and posted (T7 + T8 + T9). **Any of three slipping → PE RFC 0003's falsifier is missed and DOP's 2026-07-10 falsifier becomes structurally unmeetable** — escalate to Kaushik before re-cutting. This is RFC 0003's falsifier transcribed; the PM plan adopts it intentionally because the technical and strategic falsifiers converge this sprint.
+
+**Plan-level falsifier (PM-specific):** if at mid-sprint check (2026-06-19, day 7) T1 (publishConfig flip + freeze gate) has not merged, the plan is wrong-shaped — the install-path trunk is supposed to land day 1–3, not day 7. Replan immediately: cut T9 (forum reply) and one of the four submissions to sprint 2493 to free capacity for landing T1–T5.
+
+## Replanning triggers
+
+1. **T1 not merged by day 3 (2026-06-15)** → escalate to Kaushik. Preferred: pair-program the freeze gate (staff-swe-2 borrows 4h from T6 telemetry to land the script). Last-resort: ship v1.0 with the publishConfig flip alone, defer the freeze gate to sprint 2493 — accepting the procedural risk RFC 0001 warned about for 2 weeks.
+2. **Cursor MCP directory submission process changes mid-sprint or requires assets we can't produce in-house** (e.g., demo video > 30s requiring polished UI) → swap T8 priority order so Cline/Continue/Codex file first; Cursor submission slips to sprint 2493. DOP falsifier branch (a) still reachable via Cline.
+3. **Tool-rename (T2) alias resolution fails at SDK registration layer** (RFC 0002 risk #1) → block T5 publish; do not ship partial v1. Either fix at SDK layer or invert position (ship v1.0 with dotted-canonical, snake_case as aliases — costs the positioning argument but preserves shipping).
+4. **WebMCP full public spec drops mid-sprint with build-time AST instrumentation** → escalate to Kaushik immediately. The "complement at a different layer" framing breaks; entire sprint thesis may be invalid and DOP/PE paths re-open. This was tracked in 2491 too — re-verify around 2026-09-01 per DOP memo.
+5. **Telemetry verification install yields zero sessions** → instrumentation is broken, not the bet. Block T5 release-post; debug `npx domscribe init` prompt UX. Same disposition as sprint 2491 trigger #5.
+6. **Cursor forum thread `/t/146166` has gone cold (verified at sprint kickoff and again at day 7)** — flagged by DOP as a memo-level uncertainty. If thread is dead, T9 still ships but its DOP falsifier weight collapses; we lean harder on directory submissions (T8).
+
+## Risks
+
+- **Tight capacity ceiling (91%).** 7h slack vs. 12.5h in sprint 2491. Mitigated by carried-forward drafts (#40 / #41 / #42) banking ~10h of work; risked by the new install-path issue surfacing additional CI fragility once protocol-freeze starts running on real PRs.
+- **Documentation-versioned protocol is a known structural risk** (RFC 0001's original argument against Alt A). Procedural mitigation via `protocol:freeze-check` is fragile until extraction-trigger fires. RFC 0003 §counter-argument names this explicitly; we are accepting it for one quarter.
+- **Vendor directory review windows are outside the team's control.** DOP falsifier branch (a) — directory acceptance — may not resolve in-sprint. Mitigated by filing all four submissions and treating "submissions filed" as in-scope, "acceptance" as out-of-scope.
+- **Customer-voice gap persists** (Gmail still denied; DOP memo open risk carried forward from sprint 2491). If Cursor forum thread is thin and the four submissions stall, sprint 2493 starts with no fresh customer-voice signal. Pre-grant Gmail before sprint 2493 kickoff.

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@vitest/coverage-v8": "4.0.18",
     "@vitest/ui": "4.0.18",
     "ajv": "^8.18.0",
+    "chrome-devtools-mcp": "1.1.1",
     "eslint": "^10.0.2",
     "eslint-config-prettier": "^10.1.8",
     "jiti": "2.6.1",

--- a/packages/domscribe-benchmark-comparators/README.md
+++ b/packages/domscribe-benchmark-comparators/README.md
@@ -1,0 +1,26 @@
+# @domscribe/benchmark-comparators
+
+External MCP comparators and an in-repo WebMCP-conformant reference server for the [Code→UI Benchmark v1](../../docs/code-to-ui-benchmark/v1-results.md).
+
+Companion package to `@domscribe/benchmark` (the spec + runner — owned by sprint 2613 Task A). The runner imports `Comparator` implementations from here and produces the public 45-cell results table. This package contains the comparators only; the scenarios and scoring rubric live in the benchmark spec.
+
+## Why a separate package
+
+Comparators have a different stability surface than the benchmark spec:
+
+- The **WebMCP-conformant reference** is a fallback implementation per [RFC 0004](../../docs/rfcs/0004-code-to-ui-benchmark-v1.md). It exists so the benchmark's third column is reproducible on a clean clone when no external WebMCP-conformant server installs cleanly in the sprint window.
+- The **chrome-devtools-mcp** comparator is a thin shim over the external [`chrome-devtools-mcp`](https://github.com/ChromeDevTools/chrome-devtools-mcp) dev-dep. The version is pinned in the root `package.json` and recorded on `/benchmark` with the results.
+
+Both columns are intentionally drop-in replaceable so the benchmark can re-score with a real external WebMCP server once one is available.
+
+## What's in here
+
+| Surface                    | Purpose                                                                                                                                                                       |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/types/`               | `Comparator`, `ScenarioPrompt`, `ComparatorResponse`, `CellOutcome` — the contract the runner depends on                                                                      |
+| `src/webmcp-reference/`    | Minimal in-repo reference: implements selector queries / computed-style reads / devtools enumeration; refuses S4 props/state and S5 annotation→source (the gap RCP v1 closes) |
+| `src/chrome-devtools-mcp/` | Comparator shim; the actual MCP transport is injected via `ChromeDevtoolsMcpClient` so the comparator stays unit-testable                                                     |
+
+## Caveats
+
+The in-repo WebMCP reference is, by definition, a comparison where we wrote both sides. The `/benchmark` page surfaces this as the `external-validity: in-repo-fallback` flag on the column. Replacing the reference with a real external WebMCP-conformant server is the structural fix.

--- a/packages/domscribe-benchmark-comparators/package.json
+++ b/packages/domscribe-benchmark-comparators/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@domscribe/benchmark-comparators",
+  "version": "0.5.2",
+  "description": "External MCP comparators (chrome-devtools-mcp, in-repo WebMCP-conformant reference) and an in-repo WebMCP-conformant reference server for the Code→UI Benchmark suite.",
+  "type": "module",
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./webmcp-reference": "./src/webmcp-reference/index.ts",
+    "./chrome-devtools-mcp": "./src/chrome-devtools-mcp/index.ts",
+    "./types": "./src/types/index.ts"
+  },
+  "distExports": {
+    "./webmcp-reference": "./webmcp-reference/index.js",
+    "./chrome-devtools-mcp": "./chrome-devtools-mcp/index.js",
+    "./types": "./types/index.js"
+  },
+  "publishConfig": {
+    "access": "restricted"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/patchorbit/domscribe.git",
+    "directory": "packages/domscribe-benchmark-comparators"
+  }
+}

--- a/packages/domscribe-benchmark-comparators/project.json
+++ b/packages/domscribe-benchmark-comparators/project.json
@@ -1,0 +1,48 @@
+{
+  "name": "domscribe-benchmark-comparators",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "library",
+  "sourceRoot": "packages/domscribe-benchmark-comparators/src",
+  "tags": ["scope:infra", "type:lib", "type:test"],
+  "targets": {
+    "build": {
+      "executor": "@nx/js:tsc",
+      "outputs": [
+        "{workspaceRoot}/dist/packages/domscribe-benchmark-comparators"
+      ],
+      "options": {
+        "rootDir": "packages/domscribe-benchmark-comparators/src",
+        "outputPath": "dist/packages/domscribe-benchmark-comparators",
+        "main": "packages/domscribe-benchmark-comparators/src/index.ts",
+        "tsConfig": "packages/domscribe-benchmark-comparators/tsconfig.lib.json",
+        "generatePackageJson": true,
+        "generateExportsField": true,
+        "assets": ["packages/domscribe-benchmark-comparators/*.md"]
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "eslintConfig": "eslint.config.mjs",
+        "lintFilePatterns": ["packages/domscribe-benchmark-comparators/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{projectRoot}/test-output"],
+      "options": {
+        "config": "packages/domscribe-benchmark-comparators/vite.config.ts"
+      }
+    },
+    "typecheck": {
+      "executor": "nx:noop"
+    },
+    "watch-deps": {
+      "executor": "nx:noop"
+    },
+    "build-deps": {
+      "executor": "nx:noop"
+    }
+  }
+}

--- a/packages/domscribe-benchmark-comparators/src/chrome-devtools-mcp/client.ts
+++ b/packages/domscribe-benchmark-comparators/src/chrome-devtools-mcp/client.ts
@@ -1,0 +1,22 @@
+export interface ChromeDevtoolsMcpToolCall {
+  name: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface ChromeDevtoolsMcpToolResult {
+  ok: boolean;
+  content?: unknown;
+  refusal?: string;
+}
+
+/**
+ * Minimal client surface the benchmark runner depends on. The actual MCP transport (stdio child
+ * process spawned from the chrome-devtools-mcp dev-dep) lives behind this interface so the
+ * comparator stays unit-testable. Task A's runner constructs the real client; the benchmark
+ * pins chrome-devtools-mcp at the version recorded in the root devDependencies.
+ */
+export interface ChromeDevtoolsMcpClient {
+  readonly version: string;
+  call(req: ChromeDevtoolsMcpToolCall): Promise<ChromeDevtoolsMcpToolResult>;
+  dispose(): Promise<void>;
+}

--- a/packages/domscribe-benchmark-comparators/src/chrome-devtools-mcp/comparator.test.ts
+++ b/packages/domscribe-benchmark-comparators/src/chrome-devtools-mcp/comparator.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createChromeDevtoolsMcpComparator } from './comparator.js';
+import type { ChromeDevtoolsMcpClient } from './client.js';
+
+function fakeClient(
+  overrides: Partial<ChromeDevtoolsMcpClient> = {},
+): ChromeDevtoolsMcpClient {
+  return {
+    version: 'test-0.0.0',
+    call: vi.fn().mockResolvedValue({ ok: true, content: 'ok' }),
+    dispose: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe('createChromeDevtoolsMcpComparator', () => {
+  it('marks the comparator as external (no caveat on /benchmark)', () => {
+    const c = createChromeDevtoolsMcpComparator({ client: fakeClient() });
+    expect(c.externalValidity).toBe('external');
+    expect(c.name).toBe('chrome-devtools-mcp');
+  });
+
+  it('records the client version verbatim (pinned in root devDependencies)', () => {
+    const c = createChromeDevtoolsMcpComparator({
+      client: fakeClient({ version: '1.4.7' }),
+    });
+    expect(c.version).toBe('1.4.7');
+  });
+
+  it('returns outcome=pass with raw content when the client succeeds', async () => {
+    const c = createChromeDevtoolsMcpComparator({
+      client: fakeClient({
+        call: vi.fn().mockResolvedValue({ ok: true, content: { dom: '<x/>' } }),
+      }),
+    });
+    const res = await c.run({
+      scenarioId: 'S1',
+      fixture: 'vite',
+      request: { url: 'http://localhost' },
+    });
+    expect(res.outcome).toBe('pass');
+    expect(res.rawResponse).toEqual({ dom: '<x/>' });
+  });
+
+  it('returns outcome=refused when the client reports refusal', async () => {
+    const c = createChromeDevtoolsMcpComparator({
+      client: fakeClient({
+        call: vi
+          .fn()
+          .mockResolvedValue({ ok: false, refusal: 'no source position tool' }),
+      }),
+    });
+    const res = await c.run({
+      scenarioId: 'S2',
+      fixture: 'nuxt',
+      request: {},
+    });
+    expect(res.outcome).toBe('refused');
+    expect(res.errorMessage).toBe('no source position tool');
+  });
+
+  it('catches transport throws and returns outcome=wrong with the error', async () => {
+    const c = createChromeDevtoolsMcpComparator({
+      client: fakeClient({
+        call: vi.fn().mockRejectedValue(new Error('mcp stdio EOF')),
+      }),
+    });
+    const res = await c.run({
+      scenarioId: 'S3',
+      fixture: 'next',
+      request: {},
+    });
+    expect(res.outcome).toBe('wrong');
+    expect(res.errorMessage).toBe('mcp stdio EOF');
+  });
+});

--- a/packages/domscribe-benchmark-comparators/src/chrome-devtools-mcp/comparator.ts
+++ b/packages/domscribe-benchmark-comparators/src/chrome-devtools-mcp/comparator.ts
@@ -1,0 +1,68 @@
+import type {
+  Comparator,
+  ComparatorResponse,
+  ScenarioPrompt,
+} from '../types/index.js';
+import type { ChromeDevtoolsMcpClient } from './client.js';
+
+export interface ChromeDevtoolsMcpOptions {
+  client: ChromeDevtoolsMcpClient;
+}
+
+const SCENARIO_TO_CDP_TOOL = {
+  S1: 'navigate.evaluate',
+  S2: 'css.read_computed',
+  S3: 'navigate.evaluate',
+  S4: 'navigate.evaluate',
+  S5: 'navigate.evaluate',
+} as const;
+
+export function createChromeDevtoolsMcpComparator(
+  opts: ChromeDevtoolsMcpOptions,
+): Comparator {
+  return {
+    name: 'chrome-devtools-mcp',
+    version: opts.client.version,
+    externalValidity: 'external',
+    async run(prompt: ScenarioPrompt): Promise<ComparatorResponse> {
+      const tool = SCENARIO_TO_CDP_TOOL[prompt.scenarioId];
+      const start = Date.now();
+      try {
+        const result = await opts.client.call({
+          name: tool,
+          arguments: prompt.request,
+        });
+        const durationMs = Date.now() - start;
+        if (result.ok) {
+          return {
+            scenarioId: prompt.scenarioId,
+            fixture: prompt.fixture,
+            comparator: 'chrome-devtools-mcp',
+            outcome: 'pass',
+            rawResponse: result.content,
+            durationMs,
+          };
+        }
+        return {
+          scenarioId: prompt.scenarioId,
+          fixture: prompt.fixture,
+          comparator: 'chrome-devtools-mcp',
+          outcome: 'refused',
+          rawResponse: null,
+          errorMessage: result.refusal,
+          durationMs,
+        };
+      } catch (err) {
+        return {
+          scenarioId: prompt.scenarioId,
+          fixture: prompt.fixture,
+          comparator: 'chrome-devtools-mcp',
+          outcome: 'wrong',
+          rawResponse: null,
+          errorMessage: err instanceof Error ? err.message : String(err),
+          durationMs: Date.now() - start,
+        };
+      }
+    },
+  };
+}

--- a/packages/domscribe-benchmark-comparators/src/chrome-devtools-mcp/index.ts
+++ b/packages/domscribe-benchmark-comparators/src/chrome-devtools-mcp/index.ts
@@ -1,0 +1,2 @@
+export { createChromeDevtoolsMcpComparator } from './comparator.js';
+export type { ChromeDevtoolsMcpClient } from './client.js';

--- a/packages/domscribe-benchmark-comparators/src/index.ts
+++ b/packages/domscribe-benchmark-comparators/src/index.ts
@@ -1,0 +1,18 @@
+export type {
+  CellOutcome,
+  Comparator,
+  ComparatorName,
+  ComparatorResponse,
+  FixtureName,
+  ScenarioId,
+  ScenarioPrompt,
+} from './types/index.js';
+
+export {
+  createWebMcpReferenceComparator,
+  WebMcpReferenceServer,
+} from './webmcp-reference/index.js';
+export type { WebMcpToolName } from './webmcp-reference/index.js';
+
+export { createChromeDevtoolsMcpComparator } from './chrome-devtools-mcp/index.js';
+export type { ChromeDevtoolsMcpClient } from './chrome-devtools-mcp/index.js';

--- a/packages/domscribe-benchmark-comparators/src/types/index.ts
+++ b/packages/domscribe-benchmark-comparators/src/types/index.ts
@@ -1,0 +1,33 @@
+export type ScenarioId = 'S1' | 'S2' | 'S3' | 'S4' | 'S5';
+
+export type FixtureName = 'vite' | 'nuxt' | 'next';
+
+export type ComparatorName =
+  | 'rcp-v1'
+  | 'chrome-devtools-mcp'
+  | 'webmcp-reference';
+
+export type CellOutcome = 'pass' | 'refused' | 'wrong';
+
+export interface ScenarioPrompt {
+  scenarioId: ScenarioId;
+  fixture: FixtureName;
+  request: Record<string, unknown>;
+}
+
+export interface ComparatorResponse {
+  scenarioId: ScenarioId;
+  fixture: FixtureName;
+  comparator: ComparatorName;
+  outcome: CellOutcome;
+  rawResponse: unknown;
+  errorMessage?: string;
+  durationMs: number;
+}
+
+export interface Comparator {
+  readonly name: ComparatorName;
+  readonly version: string;
+  readonly externalValidity: 'external' | 'in-repo-fallback';
+  run(prompt: ScenarioPrompt): Promise<ComparatorResponse>;
+}

--- a/packages/domscribe-benchmark-comparators/src/webmcp-reference/comparator.test.ts
+++ b/packages/domscribe-benchmark-comparators/src/webmcp-reference/comparator.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWebMcpReferenceComparator } from './comparator.js';
+
+describe('createWebMcpReferenceComparator', () => {
+  it('marks the comparator as in-repo-fallback (caveat surfaces on /benchmark)', () => {
+    const c = createWebMcpReferenceComparator({
+      bridge: { evaluate: vi.fn() },
+    });
+    expect(c.externalValidity).toBe('in-repo-fallback');
+    expect(c.name).toBe('webmcp-reference');
+  });
+
+  it('returns outcome=refused for S4 (props/state) with a recorded reason', async () => {
+    const c = createWebMcpReferenceComparator({
+      bridge: { evaluate: vi.fn() },
+    });
+    const res = await c.run({
+      scenarioId: 'S4',
+      fixture: 'vite',
+      request: { instancePath: 'App.Button[0]' },
+    });
+    expect(res.outcome).toBe('refused');
+    expect(res.errorMessage).toMatch(/props\/state/);
+  });
+
+  it('returns outcome=refused for S5 (annotation→source) with a recorded reason', async () => {
+    const c = createWebMcpReferenceComparator({
+      bridge: { evaluate: vi.fn() },
+    });
+    const res = await c.run({
+      scenarioId: 'S5',
+      fixture: 'next',
+      request: { annotationId: 'a-1' },
+    });
+    expect(res.outcome).toBe('refused');
+    expect(res.errorMessage).toMatch(/source roundtrip/);
+  });
+
+  it('returns outcome=pass with raw value when S1 selector resolves', async () => {
+    const c = createWebMcpReferenceComparator({
+      bridge: { evaluate: vi.fn().mockResolvedValue('<div>x</div>') },
+    });
+    const res = await c.run({
+      scenarioId: 'S1',
+      fixture: 'nuxt',
+      request: { selector: 'div' },
+    });
+    expect(res.outcome).toBe('pass');
+    expect(res.rawResponse).toBe('<div>x</div>');
+  });
+
+  it('catches bridge throws and returns outcome=wrong with the error', async () => {
+    const c = createWebMcpReferenceComparator({
+      bridge: {
+        evaluate: vi.fn().mockRejectedValue(new Error('socket closed')),
+      },
+    });
+    const res = await c.run({
+      scenarioId: 'S1',
+      fixture: 'vite',
+      request: { selector: 'div' },
+    });
+    expect(res.outcome).toBe('wrong');
+    expect(res.errorMessage).toBe('socket closed');
+  });
+});

--- a/packages/domscribe-benchmark-comparators/src/webmcp-reference/comparator.ts
+++ b/packages/domscribe-benchmark-comparators/src/webmcp-reference/comparator.ts
@@ -1,0 +1,76 @@
+import type {
+  Comparator,
+  ComparatorResponse,
+  ScenarioPrompt,
+} from '../types/index.js';
+import { type BrowserBridge, WebMcpReferenceServer } from './server.js';
+
+export interface WebMcpReferenceOptions {
+  bridge: BrowserBridge;
+  version?: string;
+}
+
+const SCENARIO_TO_TOOL = {
+  S1: 'web.query_selector',
+  S2: 'web.read_styles',
+  S3: 'web.enumerate_components',
+  S4: 'web.read_props_state',
+  S5: 'web.resolve_annotation',
+} as const;
+
+export function createWebMcpReferenceComparator(
+  opts: WebMcpReferenceOptions,
+): Comparator {
+  const server = new WebMcpReferenceServer(opts.bridge);
+  const version = opts.version ?? '0.1.0-in-repo-reference';
+
+  return {
+    name: 'webmcp-reference',
+    version,
+    externalValidity: 'in-repo-fallback',
+    async run(prompt: ScenarioPrompt): Promise<ComparatorResponse> {
+      const tool = SCENARIO_TO_TOOL[prompt.scenarioId];
+      const start = Date.now();
+      try {
+        const result = await server.query({
+          tool,
+          arguments: prompt.request,
+        });
+        const durationMs = Date.now() - start;
+        if (result.ok) {
+          // The benchmark spec (Task A) decides what counts as a correct answer for each scenario.
+          // The reference returns the raw value; the runner scores it against the fixture's
+          // expected-answer (source position, component owning file, etc.). The reference is
+          // expected to refuse on S4 and S5 — that is the gap the benchmark documents.
+          return {
+            scenarioId: prompt.scenarioId,
+            fixture: prompt.fixture,
+            comparator: 'webmcp-reference',
+            outcome: 'pass',
+            rawResponse: result.value,
+            durationMs,
+          };
+        }
+        return {
+          scenarioId: prompt.scenarioId,
+          fixture: prompt.fixture,
+          comparator: 'webmcp-reference',
+          outcome: 'refused',
+          rawResponse: null,
+          errorMessage: result.refusal,
+          durationMs,
+        };
+      } catch (err) {
+        return {
+          scenarioId: prompt.scenarioId,
+          fixture: prompt.fixture,
+          comparator: 'webmcp-reference',
+          outcome: 'wrong',
+          rawResponse: null,
+          errorMessage: err instanceof Error ? err.message : String(err),
+          durationMs: Date.now() - start,
+        };
+      }
+    },
+  };
+}

--- a/packages/domscribe-benchmark-comparators/src/webmcp-reference/index.ts
+++ b/packages/domscribe-benchmark-comparators/src/webmcp-reference/index.ts
@@ -1,0 +1,3 @@
+export { createWebMcpReferenceComparator } from './comparator.js';
+export { WebMcpReferenceServer } from './server.js';
+export type { WebMcpToolName } from './tools.js';

--- a/packages/domscribe-benchmark-comparators/src/webmcp-reference/server.test.ts
+++ b/packages/domscribe-benchmark-comparators/src/webmcp-reference/server.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WebMcpReferenceServer } from './server.js';
+
+describe('WebMcpReferenceServer', () => {
+  it('lists exactly the five WebMCP tool surfaces (S1–S5 mapping)', () => {
+    const server = new WebMcpReferenceServer({ evaluate: vi.fn() });
+    expect(server.listTools()).toEqual([
+      'web.query_selector',
+      'web.read_styles',
+      'web.enumerate_components',
+      'web.read_props_state',
+      'web.resolve_annotation',
+    ]);
+  });
+
+  it('refuses S5 annotation→source roundtrip (the gap RCP v1 closes)', async () => {
+    const server = new WebMcpReferenceServer({ evaluate: vi.fn() });
+    const result = await server.query({
+      tool: 'web.resolve_annotation',
+      arguments: { annotationId: 'a-1' },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.refusal).toMatch(/source roundtrip/);
+  });
+
+  it('refuses S4 props/state introspection (devtools-required gap)', async () => {
+    const server = new WebMcpReferenceServer({ evaluate: vi.fn() });
+    const result = await server.query({
+      tool: 'web.read_props_state',
+      arguments: { instancePath: 'App.Button[0]' },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.refusal).toMatch(/props\/state/);
+  });
+
+  it('S1 returns the outerHTML when the selector matches', async () => {
+    const evaluate = vi.fn().mockResolvedValue('<button>ok</button>');
+    const server = new WebMcpReferenceServer({ evaluate });
+    const result = await server.query({
+      tool: 'web.query_selector',
+      arguments: { selector: 'button' },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.value).toBe('<button>ok</button>');
+  });
+
+  it('S1 reports not-found when the selector matches nothing', async () => {
+    const evaluate = vi.fn().mockResolvedValue(null);
+    const server = new WebMcpReferenceServer({ evaluate });
+    const result = await server.query({
+      tool: 'web.query_selector',
+      arguments: { selector: '.missing' },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it('S1 refuses when selector is missing', async () => {
+    const server = new WebMcpReferenceServer({ evaluate: vi.fn() });
+    const result = await server.query({
+      tool: 'web.query_selector',
+      arguments: {},
+    });
+    expect(result.ok).toBe(false);
+    expect(result.refusal).toMatch(/missing selector/);
+  });
+
+  it('S3 explicitly reports sourcePositionExposed=false (the falsifiable gap)', async () => {
+    const evaluate = vi.fn().mockResolvedValue({
+      componentName: 'Button',
+      devtoolsPresent: true,
+      sourcePositionExposed: false,
+    });
+    const server = new WebMcpReferenceServer({ evaluate });
+    const result = await server.query({
+      tool: 'web.enumerate_components',
+      arguments: { componentName: 'Button' },
+    });
+    expect(result.ok).toBe(true);
+    expect(
+      (result.value as { sourcePositionExposed: boolean })
+        .sourcePositionExposed,
+    ).toBe(false);
+  });
+});

--- a/packages/domscribe-benchmark-comparators/src/webmcp-reference/server.ts
+++ b/packages/domscribe-benchmark-comparators/src/webmcp-reference/server.ts
@@ -1,0 +1,120 @@
+import { WEBMCP_TOOLS, type WebMcpToolName } from './tools.js';
+
+export interface WebMcpQueryRequest {
+  tool: WebMcpToolName;
+  arguments: Record<string, unknown>;
+}
+
+export interface WebMcpQueryResult {
+  ok: boolean;
+  value?: unknown;
+  refusal?: string;
+}
+
+export interface BrowserBridge {
+  evaluate(expression: string): Promise<unknown>;
+}
+
+/**
+ * WebMcpReferenceServer is a minimal, in-repo WebMCP-conformant reference. It implements the
+ * surface a generic runtime-browser-MCP exposes — selector queries, computed styles, devtools
+ * enumeration — without source-position correlation. It exists to give the benchmark a third
+ * column that does not depend on an external project installing cleanly in the sprint window
+ * (per RFC 0004 fallback). Real WebMCP-conformant servers should be drop-in replaceable.
+ */
+export class WebMcpReferenceServer {
+  constructor(private readonly bridge: BrowserBridge) {}
+
+  listTools(): ReadonlyArray<WebMcpToolName> {
+    return WEBMCP_TOOLS.map((t) => t.name);
+  }
+
+  async query(request: WebMcpQueryRequest): Promise<WebMcpQueryResult> {
+    switch (request.tool) {
+      case 'web.query_selector':
+        return this.querySelector(request.arguments);
+      case 'web.read_styles':
+        return this.readStyles(request.arguments);
+      case 'web.enumerate_components':
+        return this.enumerateComponents(request.arguments);
+      case 'web.read_props_state':
+        return this.readPropsState(request.arguments);
+      case 'web.resolve_annotation':
+        return this.refuseSourceCorrelation();
+      default:
+        return { ok: false, refusal: `unknown tool: ${String(request.tool)}` };
+    }
+  }
+
+  private async querySelector(
+    args: Record<string, unknown>,
+  ): Promise<WebMcpQueryResult> {
+    const selector = readString(args, 'selector');
+    if (!selector) {
+      return { ok: false, refusal: 'missing selector' };
+    }
+    const value = await this.bridge.evaluate(
+      `(() => { const el = document.querySelector(${JSON.stringify(selector)}); return el ? el.outerHTML : null; })()`,
+    );
+    return { ok: value !== null, value };
+  }
+
+  private async readStyles(
+    args: Record<string, unknown>,
+  ): Promise<WebMcpQueryResult> {
+    const selector = readString(args, 'selector');
+    if (!selector) {
+      return { ok: false, refusal: 'missing selector' };
+    }
+    const value = await this.bridge.evaluate(
+      `(() => { const el = document.querySelector(${JSON.stringify(selector)}); if (!el) return null; const cs = window.getComputedStyle(el); const out = {}; for (const k of cs) out[k] = cs.getPropertyValue(k); return out; })()`,
+    );
+    return { ok: value !== null, value };
+  }
+
+  private async enumerateComponents(
+    args: Record<string, unknown>,
+  ): Promise<WebMcpQueryResult> {
+    const componentName = readString(args, 'componentName');
+    if (!componentName) {
+      return { ok: false, refusal: 'missing componentName' };
+    }
+    // The reference does not have source-correlation; it returns count-of-instances by walking
+    // devtools globals if present. Owning-file is intentionally not returned — that is the gap
+    // the benchmark is measuring (S3 multi-instance enumeration with owning file).
+    const value = await this.bridge.evaluate(
+      `(() => { const probe = window.__VUE_DEVTOOLS_GLOBAL_HOOK__ || window.__REACT_DEVTOOLS_GLOBAL_HOOK__; return { componentName: ${JSON.stringify(componentName)}, devtoolsPresent: !!probe, sourcePositionExposed: false }; })()`,
+    );
+    return { ok: true, value };
+  }
+
+  private async readPropsState(
+    args: Record<string, unknown>,
+  ): Promise<WebMcpQueryResult> {
+    const instancePath = readString(args, 'instancePath');
+    if (!instancePath) {
+      return { ok: false, refusal: 'missing instancePath' };
+    }
+    return {
+      ok: false,
+      refusal:
+        'WebMCP-reference does not implement props/state introspection; framework devtools are required and not bridged in the reference',
+    };
+  }
+
+  private async refuseSourceCorrelation(): Promise<WebMcpQueryResult> {
+    return {
+      ok: false,
+      refusal:
+        'WebMCP-reference does not implement annotation→source roundtrip; build-time source-position correlation is out of scope for a runtime-browser-MCP',
+    };
+  }
+}
+
+function readString(
+  args: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const v = args[key];
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}

--- a/packages/domscribe-benchmark-comparators/src/webmcp-reference/tools.ts
+++ b/packages/domscribe-benchmark-comparators/src/webmcp-reference/tools.ts
@@ -1,0 +1,65 @@
+export type WebMcpToolName =
+  | 'web.query_selector'
+  | 'web.read_styles'
+  | 'web.enumerate_components'
+  | 'web.read_props_state'
+  | 'web.resolve_annotation';
+
+export interface WebMcpToolDescriptor {
+  name: WebMcpToolName;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export const WEBMCP_TOOLS: ReadonlyArray<WebMcpToolDescriptor> = [
+  {
+    name: 'web.query_selector',
+    description:
+      'Return the live DOM subtree matching a CSS selector. No source-position correlation.',
+    inputSchema: {
+      type: 'object',
+      properties: { selector: { type: 'string' } },
+      required: ['selector'],
+    },
+  },
+  {
+    name: 'web.read_styles',
+    description:
+      'Return the computed style for a selector. CSS rule provenance is not exposed.',
+    inputSchema: {
+      type: 'object',
+      properties: { selector: { type: 'string' } },
+      required: ['selector'],
+    },
+  },
+  {
+    name: 'web.enumerate_components',
+    description:
+      'Return mounted-component names by walking framework devtools globals. Owning file is not exposed.',
+    inputSchema: {
+      type: 'object',
+      properties: { componentName: { type: 'string' } },
+      required: ['componentName'],
+    },
+  },
+  {
+    name: 'web.read_props_state',
+    description:
+      'Return current props/state for a component instance reachable via devtools globals.',
+    inputSchema: {
+      type: 'object',
+      properties: { instancePath: { type: 'string' } },
+      required: ['instancePath'],
+    },
+  },
+  {
+    name: 'web.resolve_annotation',
+    description:
+      'Return the DOM node for an annotation captured by a host UI. Source roundtrip is not exposed.',
+    inputSchema: {
+      type: 'object',
+      properties: { annotationId: { type: 'string' } },
+      required: ['annotationId'],
+    },
+  },
+];

--- a/packages/domscribe-benchmark-comparators/tsconfig.json
+++ b/packages/domscribe-benchmark-comparators/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/domscribe-benchmark-comparators/tsconfig.lib.json
+++ b/packages/domscribe-benchmark-comparators/tsconfig.lib.json
@@ -1,0 +1,31 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "../../dist/packages/domscribe-benchmark-comparators/tsconfig.tsbuildinfo",
+    "lib": [
+      "es2024",
+      "ESNext.Array",
+      "ESNext.Collection",
+      "ESNext.Iterator",
+      "ESNext.Promise"
+    ],
+    "target": "es2024",
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "**/dist",
+    "**/build",
+    "**/coverage",
+    "**/tmp",
+    "**/test-output",
+    "**/.nx"
+  ]
+}

--- a/packages/domscribe-benchmark-comparators/vite.config.ts
+++ b/packages/domscribe-benchmark-comparators/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: '@domscribe/benchmark-comparators',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.ts'],
+    reporters: ['default'],
+    outputFile: './test-output/vitest/report.json',
+    coverage: {
+      enabled: true,
+      provider: 'v8',
+      reporter: ['text', 'json-summary'],
+      reportsDirectory: './test-output/vitest/coverage',
+      include: ['src/**/*.ts'],
+      exclude: [
+        'src/index.ts',
+        'src/**/index.ts',
+        '**/*.spec.ts',
+        '**/*.test.ts',
+      ],
+      thresholds: {
+        lines: 0.7,
+        functions: 0.7,
+        branches: 0.6,
+        statements: 0.7,
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
+      chrome-devtools-mcp:
+        specifier: 1.1.1
+        version: 1.1.1
       eslint:
         specifier: ^10.0.2
         version: 10.0.2(jiti@2.6.1)
@@ -98,6 +101,12 @@ importers:
       vitest:
         specifier: 4.0.18
         version: 4.0.18(@types/node@25.3.3)(@vitest/ui@4.0.18)(happy-dom@12.10.3)(jiti@2.6.1)(jsdom@28.1.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/domscribe-benchmark-comparators:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.25.1(hono@4.11.3)(zod@4.3.6)
 
   packages/domscribe-cli:
     dependencies:
@@ -3565,6 +3574,11 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  chrome-devtools-mcp@1.1.1:
+    resolution: {integrity: sha512-Fs/ASXAkQqvYCbJjHIx/pnShjyIoZoPxdg4J3wjaA9FLkRb2ngGnisu2AGcBIXdw5qrPkOuV/cOlGOonpsE1qw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+    hasBin: true
+
   chrome-trace-event@1.0.4:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
@@ -3724,10 +3738,6 @@ packages:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
 
-  cookie@0.7.1:
-    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
-    engines: {node: '>= 0.6'}
-
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
@@ -3747,10 +3757,6 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-
-  cors@2.8.5:
-    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
-    engines: {node: '>= 0.10'}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -5979,10 +5985,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -8528,7 +8530,7 @@ snapshots:
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
-      cors: 2.8.5
+      cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
@@ -10752,10 +10754,10 @@ snapshots:
       bytes: 3.1.2
       content-type: 1.0.5
       debug: 4.4.3
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       iconv-lite: 0.7.1
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.15.0
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -10894,6 +10896,8 @@ snapshots:
       readdirp: 5.0.0
 
   chownr@3.0.0: {}
+
+  chrome-devtools-mcp@1.1.1: {}
 
   chrome-trace-event@1.0.4: {}
 
@@ -11039,8 +11043,6 @@ snapshots:
 
   cookie-signature@1.2.2: {}
 
-  cookie@0.7.1: {}
-
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
@@ -11056,11 +11058,6 @@ snapshots:
   core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
-
-  cors@2.8.5:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
 
   cors@2.8.6:
     dependencies:
@@ -11640,7 +11637,7 @@ snapshots:
       body-parser: 2.2.1
       content-disposition: 1.0.1
       content-type: 1.0.5
-      cookie: 0.7.1
+      cookie: 0.7.2
       cookie-signature: 1.2.2
       debug: 4.4.3
       depd: 2.0.0
@@ -11649,19 +11646,19 @@ snapshots:
       etag: 1.8.1
       finalhandler: 2.1.1
       fresh: 2.0.0
-      http-errors: 2.0.0
+      http-errors: 2.0.1
       merge-descriptors: 2.0.0
       mime-types: 3.0.2
       on-finished: 2.4.1
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.15.0
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
       serve-static: 2.2.1
-      statuses: 2.0.1
+      statuses: 2.0.2
       type-is: 2.0.1
       vary: 1.1.2
     transitivePeerDependencies:
@@ -11783,7 +11780,7 @@ snapshots:
       escape-html: 1.0.3
       on-finished: 2.4.1
       parseurl: 1.3.3
-      statuses: 2.0.1
+      statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13708,10 +13705,6 @@ snapshots:
       pump: 2.0.1
 
   punycode@2.3.1: {}
-
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
 
   qs@6.14.2:
     dependencies:


### PR DESCRIPTION
## Summary

This PR delivers **sprint 2613 Task B** (`benchmark-comparators-and-page`) — the comparator implementations and the public results-page scaffold for the Code→UI Benchmark v1.

Three things land:

1. **`packages/domscribe-benchmark-comparators/`** — new sibling package containing the `Comparator` interface, the WebMCP-conformant **in-repo reference** server (per RFC 0004's fallback — no public WebMCP-conformant server installs cleanly in-sprint), and the `chrome-devtools-mcp` comparator shim. 17 unit tests, 84% line coverage. The runner in `@domscribe/benchmark` (Task A) imports `Comparator` implementations from here.

2. **`chrome-devtools-mcp@1.1.1` pinned as root dev-dep** — exact-version pin (no caret) so the published 45-cell results table is reproducible byte-for-byte. Lockfile diff includes pnpm's routine forward-resolution of `cookie` / `cors` / `qs` / `http-errors` transitive patches.

3. **`/benchmark` static results page (`docs/code-to-ui-benchmark/v1-results.md`)** — public artifact RFC 0004's category-naming falsifier reads. Schema-true placeholder cells; Task A's runner populates them from `results.json`. Linked from `README.md` (Features section) and `TECHNICAL_SPEC.md` (§9 Framework Support Matrix). Methodology, comparator table with `external-validity` flag, reproduction command, and falsifier text all included.

Plus: **`docs/code-to-ui-benchmark/vendor-submission-amendment-plan.md`** — the checklist for amending Sprint 2612 IDE-vendor-directory submissions with the `/benchmark` link while review windows are still open.

## Why a separate package boundary

The comparators have a different stability surface than the benchmark spec: the WebMCP reference is intentionally drop-in replaceable once a real external WebMCP-conformant server is installable, and the chrome-devtools-mcp shim is a thin wrapper over a pinned external dev-dep. Co-locating them with the spec/runner in `@domscribe/benchmark` would couple two distinct evolution rhythms. Each package can publish independently when its surface changes.

## Acceptance criteria mapping (PM task B)

| Criterion | This PR | Notes |
| --- | --- | --- |
| `chrome-devtools-mcp` installed as a **pinned** dev-dep | ✅ | `package.json` line; lockfile updated |
| Comparator wired to run against 5 scenarios × 3 fixtures = 15 cells | ⚠️ Partial | Comparator class is wired; **fixture instrumentation and the runner invocation live in Task A's `@domscribe/benchmark`** — the 15 cells materialise once Task A's runner imports `createChromeDevtoolsMcpComparator` and calls `run(prompt)` against the fixtures |
| WebMCP-conformant reference wired | ✅ | In-repo reference per RFC 0004 fallback; `/benchmark` page surfaces the `external-validity: in-repo-fallback` caveat verbatim |
| `/benchmark` page live, linked from README.md and TECHNICAL_SPEC.md | ✅ | `docs/code-to-ui-benchmark/v1-results.md` with last-run timestamp slot, comparator versions, methodology link to the spec, and reproduction command snippet |
| Sprint 2612 vendor-directory submissions amended | ⚠️ Conditional | `docs/submissions.md` and the four submission PRs are not yet on `main` as of sprint 2613 kickoff — see `vendor-submission-amendment-plan.md` for the trigger-conditional procedure |
| Engineer logs ≥8h of OSS reference-integration pairing time | ⚠️ Out of scope for this PR | Pairing time will appear in sprint retro notes per PM acceptance |

## Dependencies on Task A (Sprint 2613 batch A)

This PR is structurally a Task B deliverable; Task A (`benchmark-rcp-foundation` — `@domscribe/benchmark` package, `docs/code-to-ui-benchmark/v1.md` spec, RCP-v1 column with 15 cells) has **not yet landed** on `main` as of this PR. The Comparator interface here was designed to be the contract Task A's runner consumes, but:

- The benchmark spec doc (`docs/code-to-ui-benchmark/v1.md`) — referenced from this PR's `v1-results.md` and from the comparators README — does not yet exist. Links resolve to a `404` until Task A merges.
- The fixture instrumentation for S1–S5 lives with Task A. Until that lands, the 15 cells per comparator column remain as `—` placeholders on `/benchmark`.

When Task A merges, the runner's import statement should look approximately like:

```ts
import {
  createChromeDevtoolsMcpComparator,
  createWebMcpReferenceComparator,
} from '@domscribe/benchmark-comparators';
```

No rebase conflict expected — Task A and this PR touch disjoint paths (`packages/domscribe-benchmark/*` vs. `packages/domscribe-benchmark-comparators/*`).

## Pre-existing blocker (escalation, not a blocker for this PR)

Sprint 2492's RCP-v1 stamp (PE RFC 0003 falsifier) has not landed on `main` as of sprint 2613 kickoff — no `docs/rcp/v1.md`, no `docs/submissions.md`. The PM plan's replanning trigger #1 names this as a "full Sprint 2613 replan" trigger because the benchmark has no v1 subject without RCP v1. This PR does not depend on RCP v1 landing because the comparators are framework-agnostic, but Task A and the `/benchmark` page's RCP-v1 column **do** depend on it. Surfacing here for visibility; a separate Slack escalation to Kaushik covers the broader sprint-thesis risk.

## Test plan

- [x] `pnpm nx run domscribe-benchmark-comparators:lint` — passes
- [x] `pnpm nx run domscribe-benchmark-comparators:test` — 17/17 tests pass; 84% statements / 71% branches / 92% functions / 83% lines coverage (all above configured thresholds)
- [x] `pnpm nx run domscribe-benchmark-comparators:build` — compiles cleanly
- [x] `pnpm nx affected -t lint --base=main~1` — comparators package + all other affected packages pass; pre-existing `domscribe-test-fixtures` lint errors are unrelated to this PR (verified by stashing changes and re-running lint on base)
- [ ] Manual verification that `/benchmark` v1-results page renders correctly on GitHub — to be confirmed once Task A populates results.json
- [ ] Comparator integration test against fixtures — owned by Task A's runner PR