### PR TITLE
feat: build-time component-style attribution (RFC 0001 — Task A)

### DIFF
--- a/packages/domscribe-core/src/lib/migrations/annotation-migrations.spec.ts
+++ b/packages/domscribe-core/src/lib/migrations/annotation-migrations.spec.ts
@@ -56,15 +56,16 @@ describe('migrateAnnotation', () => {
     expect(result.metadata.schemaVersion).toBe(ANNOTATION_SCHEMA_VERSION);
   });
 
-  it('should default to version 1 when metadata has no schemaVersion', () => {
-    // With ANNOTATION_SCHEMA_VERSION === 1 and no field, readVersion returns 1.
-    // Since 1 === ANNOTATION_SCHEMA_VERSION, no migration steps run — it just stamps.
+  it('should walk legacy (unversioned) data forward to the current version', () => {
+    // readVersion defaults missing metadata.schemaVersion to 1, so a legacy
+    // annotation is migrated through every registered step up to the current
+    // version and then stamped.
     const raw = buildRawAnnotation();
     delete (raw['metadata'] as Record<string, unknown>)['schemaVersion'];
 
     const result = migrateAnnotation(raw);
 
-    expect(result.metadata.schemaVersion).toBe(1);
+    expect(result.metadata.schemaVersion).toBe(ANNOTATION_SCHEMA_VERSION);
   });
 
   it('should default to version 1 when metadata is missing entirely', () => {
@@ -101,5 +102,43 @@ describe('migrateAnnotation', () => {
     expect(result.interaction.type).toBe('element-annotation');
     expect(result.context.pageUrl).toBe('http://localhost:3000');
     expect(result.context.viewport).toEqual({ width: 1920, height: 1080 });
+  });
+
+  it('should migrate a v1 annotation up to v2 (additive, no field rewrite)', () => {
+    // Simulates a v1 annotation persisted before RFC 0001 schema bump.
+    // The v1 → v2 step is purely additive (componentStyles + styleSource
+    // are new optional fields) — the migration must not rewrite or delete
+    // any existing payload data.
+    const raw = buildRawAnnotation({
+      metadata: { schemaVersion: 1 },
+      context: {
+        pageUrl: 'http://localhost:3000',
+        pageTitle: 'Test',
+        viewport: { width: 1920, height: 1080 },
+        userAgent: 'test-agent',
+        runtimeContext: {
+          componentProps: { foo: 'bar' },
+        },
+      },
+    });
+
+    const result = migrateAnnotation(raw);
+
+    expect(result.metadata.schemaVersion).toBe(ANNOTATION_SCHEMA_VERSION);
+    expect(result.context.runtimeContext).toEqual({
+      componentProps: { foo: 'bar' },
+    });
+  });
+
+  it('should leave v1 payloads structurally untouched (forward-compat for v1-pinned clients)', () => {
+    // Forward-compat guarantee for annotation-process.tool: a v1-pinned
+    // downstream consumer reading a v2-migrated annotation sees exactly the
+    // v1 fields it already understood. The new componentStyles slot is
+    // optional and is absent (`undefined`) on migrated v1 payloads.
+    const raw = buildRawAnnotation({ metadata: { schemaVersion: 1 } });
+
+    const result = migrateAnnotation(raw);
+
+    expect(result.context.runtimeContext).toBeUndefined();
   });
 });

--- a/packages/domscribe-core/src/lib/migrations/annotation-migrations.ts
+++ b/packages/domscribe-core/src/lib/migrations/annotation-migrations.ts
@@ -16,12 +16,22 @@ import {
 /**
  * Registry of migration functions keyed by the version they migrate FROM.
  * e.g. migrationSteps[1] migrates v1 → v2.
- *
- * Currently empty — only v1 exists.  When a v2 schema is introduced, add:
- *   migrationSteps[1] = (data: Record<string, unknown>) => { … mutate … };
  */
 const migrationSteps: Record<number, (data: Record<string, unknown>) => void> =
-  {};
+  {
+    /**
+     * v1 → v2: additive only (per RFC 0001).
+     *
+     * v2 adds optional `runtimeContext.componentStyles` and optional
+     * `manifestSnapshot[].styleSource`. Both are optional and absent on v1
+     * payloads, so no field rewriting is required — the migration step
+     * exists purely to satisfy the version-walk contract and to let v1
+     * annotations be stamped as v2 on next write without throwing.
+     */
+    1: () => {
+      // No-op: v1 → v2 is purely additive.
+    },
+  };
 
 /**
  * Read `metadata.schemaVersion` from raw JSON, defaulting to 1 for

--- a/packages/domscribe-core/src/lib/types/annotation.ts
+++ b/packages/domscribe-core/src/lib/types/annotation.ts
@@ -54,9 +54,46 @@ export const EnvironmentSchema = z.object({
   packageManager: z.string().optional().describe('Package manager used'),
 });
 
+/**
+ * Runtime style snapshot for the annotated element.
+ *
+ * Captured by `@domscribe/runtime` at interaction time when
+ * `domscribe.config.captureStyles` is enabled. Two slots:
+ *
+ * - `computed`: a fixed allowlist of computed-style properties (≤32 entries
+ *   covering layout, spacing, typography, visual, and positioning). This is
+ *   the ground truth for "what the user sees" — survives conditional class
+ *   names, responsive variants, and runtime theme switches that build-time
+ *   attribution alone cannot resolve.
+ * - `customProperties`: resolved CSS custom properties (`--*` vars) on the
+ *   element and its ancestors up to `:root`. Lets the agent recover the
+ *   design-system token boundary without re-resolving Tailwind config or a
+ *   styled-components theme.
+ *
+ * Both fields are optional. Capture is best-effort and respects the
+ * existing per-element serialization budget (≤4 KB).
+ */
+export const ComponentStylesSchema = z.object({
+  computed: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      'Subset of computed CSS properties for the element, drawn from a fixed ≤32-property allowlist',
+    ),
+  customProperties: z
+    .record(z.string(), z.string())
+    .optional()
+    .describe(
+      'Resolved CSS custom properties (--* variables) inherited by the element from itself up to :root',
+    ),
+});
+
 export const RuntimeContextSchema = z.object({
   componentProps: z.unknown().optional().describe('Component props snapshot'),
   componentState: z.unknown().optional().describe('Component state snapshot'),
+  componentStyles: ComponentStylesSchema.optional().describe(
+    'Computed-style allowlist + resolved CSS custom properties (captured when domscribe.config.captureStyles is enabled)',
+  ),
   eventFlow: z.unknown().optional().describe('Event flow breadcrumbs'),
   performance: z.unknown().optional().describe('Performance metrics'),
 });
@@ -68,8 +105,14 @@ export const AnnotationIdSchema = z
 
 /**
  * Current annotation schema version. Bump when the Annotation shape changes.
+ *
+ * Version history:
+ * - v1: initial schema.
+ * - v2: added optional `runtimeContext.componentStyles` (computed-style
+ *   allowlist + CSS custom properties) and optional `styleSource` on
+ *   embedded `manifestSnapshot` entries, per RFC 0001.
  */
-export const ANNOTATION_SCHEMA_VERSION = 1;
+export const ANNOTATION_SCHEMA_VERSION = 2;
 
 export const AnnotationMetadataSchema = z.object({
   id: AnnotationIdSchema,
@@ -196,3 +239,57 @@ export type BoundingRect = z.infer<typeof BoundingRectSchema>;
 export type Viewport = z.infer<typeof ViewportSchema>;
 export type Environment = z.infer<typeof EnvironmentSchema>;
 export type RuntimeContext = z.infer<typeof RuntimeContextSchema>;
+export type ComponentStyles = z.infer<typeof ComponentStylesSchema>;
+
+/**
+ * Allowlist of computed-style property names captured by the runtime
+ * `StyleCapturer` (≤32 entries). Lives in `@domscribe/core` so the
+ * runtime, the relay, and downstream tools agree on the contract.
+ *
+ * Covers layout, spacing, typography, visual, and positioning — chosen to
+ * be a useful styling-debug subset without bloating the per-element
+ * serialization budget.
+ */
+export const COMPONENT_STYLES_ALLOWLIST = [
+  // Layout
+  'display',
+  'position',
+  'flex-direction',
+  'flex-wrap',
+  'align-items',
+  'justify-content',
+  'gap',
+  'grid-template-columns',
+  'grid-template-rows',
+  // Spacing
+  'margin',
+  'padding',
+  'width',
+  'height',
+  'min-width',
+  'min-height',
+  'max-width',
+  'max-height',
+  // Typography
+  'font-family',
+  'font-size',
+  'font-weight',
+  'line-height',
+  'letter-spacing',
+  'text-align',
+  'color',
+  // Visual
+  'background-color',
+  'border',
+  'border-radius',
+  'box-shadow',
+  'opacity',
+  // Positioning
+  'top',
+  'right',
+  'bottom',
+  'left',
+] as const satisfies readonly string[];
+
+export type ComponentStylesAllowlist =
+  (typeof COMPONENT_STYLES_ALLOWLIST)[number];

--- a/packages/domscribe-core/src/lib/types/manifest.ts
+++ b/packages/domscribe-core/src/lib/types/manifest.ts
@@ -26,6 +26,86 @@ export const StyleInfoSchema = z.object({
 });
 
 /**
+ * Source-block location for a CSS-in-JS declaration (styled-components or emotion).
+ *
+ * Recorded at transform time for elements rendered by a locally-declared
+ * styled-component (e.g. `const StyledDiv = styled.div\`...\`;` used as
+ * `<StyledDiv>`). Lets agents jump from the runtime DOM back to the
+ * authoring source without re-deriving the binding from a hashed class name.
+ */
+export const CssInJsSourceLocationSchema = z.object({
+  file: z
+    .string()
+    .describe('Source file path containing the styled declaration'),
+  line: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe('Line number of the styled declaration (1-indexed)'),
+  column: z
+    .number()
+    .int()
+    .nonnegative()
+    .describe('Column number of the styled declaration (0-indexed)'),
+  blockText: z
+    .string()
+    .describe(
+      'Verbatim source text of the styled template literal or css block (truncated to 4 KB)',
+    ),
+  library: z
+    .enum(['styled-components', 'emotion', 'unknown'])
+    .optional()
+    .describe('Detected CSS-in-JS library, when statically inferable'),
+  kind: z
+    .enum(['styled-tag', 'styled-call', 'css-template'])
+    .optional()
+    .describe(
+      'AST pattern that matched: styled.div (styled-tag), styled(Component) (styled-call), or css`...` (css-template)',
+    ),
+});
+
+/**
+ * Build-time style attribution for a manifest entry.
+ *
+ * Captured by `@domscribe/transform` on the same AST visit that injects
+ * `data-ds` attributes. Provides the agent with a static link from the
+ * rendered element to the styling source that produced it, so styling-shaped
+ * annotations can be resolved without a runtime round trip for the
+ * source-attribution step.
+ *
+ * @remarks
+ * - `className` is the raw value of the JSX `className` attribute when it is
+ *   statically extractable (string literal or single template literal with
+ *   no interpolations). Computed expressions yield `undefined`.
+ * - `classes` is the array of utility-class tokens statically derivable from
+ *   the `className` expression, including tokens reachable through `clsx`,
+ *   `cn`, `tw`, conditional expressions, and string-only template literals.
+ *   Tokens reachable only through runtime values are silently dropped.
+ * - `cssInJs` is set when the JSX tag references a locally-declared
+ *   styled-component in the same source file.
+ *
+ * All fields are optional: a partial attribution is preferable to a throw,
+ * and absence is the correct signal to fall back to reading the source.
+ */
+export const StyleSourceSchema = z.object({
+  className: z
+    .string()
+    .optional()
+    .describe(
+      'Statically-resolvable className literal as it appears in source; undefined when className is fully computed at runtime',
+    ),
+  classes: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Parsed utility-class tokens reachable statically from the className expression',
+    ),
+  cssInJs: CssInJsSourceLocationSchema.optional().describe(
+    'Source-block location for the CSS-in-JS declaration backing this element',
+  ),
+});
+
+/**
  * Framework-specific component metadata
  */
 export const ComponentMetadataSchema = z.record(
@@ -73,6 +153,9 @@ export const ManifestEntrySchema = z.object({
     .string()
     .optional()
     .describe('xxhash64 hash of file content at transform time (16 hex chars)'),
+  styleSource: StyleSourceSchema.optional().describe(
+    'Build-time style attribution (className tokens + CSS-in-JS source-block location)',
+  ),
 });
 
 export const ManifestMetadataSchema = z.object({
@@ -107,6 +190,8 @@ export const ManifestIndexSchema = z.object({
 export type SourcePosition = z.infer<typeof SourcePositionSchema>;
 export type StyleInfo = z.infer<typeof StyleInfoSchema>;
 export type ComponentMetadata = z.infer<typeof ComponentMetadataSchema>;
+export type CssInJsSourceLocation = z.infer<typeof CssInJsSourceLocationSchema>;
+export type StyleSource = z.infer<typeof StyleSourceSchema>;
 
 export type ManifestEntryId = z.infer<typeof ManifestEntryIdSchema>;
 export type ManifestEntry = z.infer<typeof ManifestEntrySchema>;

--- a/packages/domscribe-relay/src/mcp/tools/manifest-query.tool.ts
+++ b/packages/domscribe-relay/src/mcp/tools/manifest-query.tool.ts
@@ -51,7 +51,8 @@ export class ManifestQueryTool implements McpToolDefinition<
     'Query the Domscribe manifest to find UI elements by file, component, or tag name. ' +
     'Use to explore what elements exist in a file ("what\'s in Button.tsx?"), ' +
     'find all instances of a component ("find all Modal elements"), ' +
-    'or list elements by tag ("show all input elements").';
+    'or list elements by tag ("show all input elements"). ' +
+    'Entries include `styleSource` when build-time style capture is enabled (statically-resolvable className tokens + CSS-in-JS source-block location) — useful when triaging a styling annotation before requesting live runtime context.';
   inputSchema = ManifestQueryToolInputSchema;
   outputSchema = ManifestQueryToolOutputSchema;
 

--- a/packages/domscribe-relay/src/mcp/tools/resolve.tool.spec.ts
+++ b/packages/domscribe-relay/src/mcp/tools/resolve.tool.spec.ts
@@ -38,11 +38,50 @@ describe('ResolveTool', () => {
         end: { line: 10, column: 30 },
         componentName: 'Button',
         tagName: 'button',
+        styleSource: undefined,
         error: undefined,
       });
       expect(JSON.parse(getResultText(result))).toEqual(
         result.structuredContent,
       );
+    });
+
+    it('should forward styleSource when present on the manifest entry', async () => {
+      // Build-time style capture path (RFC 0001): when the transform was
+      // run with captureStyles enabled, the entry carries className tokens
+      // and any CSS-in-JS source-block info. The tool must pass it through.
+      const mockClient = createMockRelayClient({
+        resolveManifestEntry: vi.fn().mockResolvedValue({
+          success: true,
+          entry: {
+            file: 'src/components/Button.tsx',
+            start: { line: 10, column: 5 },
+            end: { line: 10, column: 30 },
+            componentName: 'Button',
+            tagName: 'button',
+            styleSource: {
+              className: 'px-4 py-2 bg-blue-500',
+              classes: ['px-4', 'py-2', 'bg-blue-500'],
+            },
+          },
+        }),
+      });
+      const tool = new ResolveTool(mockClient);
+
+      const result: CallToolResult = await tool.toolCallback({
+        entryId: 'ds_abc123',
+      });
+
+      expect(
+        (
+          result.structuredContent as {
+            styleSource?: { classes?: string[]; className?: string };
+          }
+        )?.styleSource,
+      ).toEqual({
+        className: 'px-4 py-2 bg-blue-500',
+        classes: ['px-4', 'py-2', 'bg-blue-500'],
+      });
     });
 
     it('should handle not-found entries', async () => {
@@ -68,6 +107,7 @@ describe('ResolveTool', () => {
         end: undefined,
         componentName: undefined,
         tagName: undefined,
+        styleSource: undefined,
         error: 'Entry not found',
       });
     });

--- a/packages/domscribe-relay/src/mcp/tools/resolve.tool.ts
+++ b/packages/domscribe-relay/src/mcp/tools/resolve.tool.ts
@@ -5,7 +5,7 @@ import {
   MCP_TOOLS,
   mcpErrorResult,
 } from './tool.defs.js';
-import { SourcePositionSchema } from '@domscribe/core';
+import { SourcePositionSchema, StyleSourceSchema } from '@domscribe/core';
 import { RelayHttpClient } from '../../client/relay-http-client.js';
 
 const ResolveToolInputSchema = z.object({
@@ -23,6 +23,9 @@ const ResolveToolOutputSchema = McpToolOutputSchema.extend({
   end: SourcePositionSchema.optional(),
   componentName: z.string().optional(),
   tagName: z.string().optional(),
+  styleSource: StyleSourceSchema.optional().describe(
+    'Build-time style attribution (className tokens + CSS-in-JS source-block location). Present only when the transform was run with domscribe.config.captureStyles enabled and the element had statically-resolvable styles.',
+  ),
 });
 
 type ResolveToolOutput = z.infer<typeof ResolveToolOutputSchema>;
@@ -35,6 +38,7 @@ export class ResolveTool implements McpToolDefinition<
   description =
     'Resolve a Domscribe element ID (data-ds attribute) to its source code location. ' +
     'Returns file path, line/column positions, component name, and tag name. ' +
+    'When build-time style capture is enabled, also returns `styleSource` — the statically-resolvable className tokens and CSS-in-JS source-block location for the element, so styling annotations can be answered without a runtime round trip. ' +
     'Use when you have a data-ds ID and need to find where the element is defined in source code.';
   inputSchema = ResolveToolInputSchema;
   outputSchema = ResolveToolOutputSchema;
@@ -54,6 +58,7 @@ export class ResolveTool implements McpToolDefinition<
         end: result.entry?.end,
         componentName: result.entry?.componentName,
         tagName: result.entry?.tagName,
+        styleSource: result.entry?.styleSource,
         error: result.error,
       };
 

--- a/packages/domscribe-relay/src/server/services/storage/file-annotation-storage.spec.ts
+++ b/packages/domscribe-relay/src/server/services/storage/file-annotation-storage.spec.ts
@@ -14,6 +14,7 @@ import {
 import path from 'path';
 import { tmpdir } from 'os';
 import {
+  ANNOTATION_SCHEMA_VERSION,
   AnnotationStatusEnum,
   type Annotation,
   type AnnotationStatus,
@@ -221,7 +222,7 @@ describe('FileAnnotationStorage', () => {
         AnnotationStatusEnum.QUEUED,
       );
       expect(result).not.toBeNull();
-      expect(result?.metadata.schemaVersion).toBe(1);
+      expect(result?.metadata.schemaVersion).toBe(ANNOTATION_SCHEMA_VERSION);
     });
 
     it('should stamp schemaVersion on listByStatus when missing from persisted data', async () => {
@@ -231,7 +232,7 @@ describe('FileAnnotationStorage', () => {
 
       const results = await storage.listByStatus(AnnotationStatusEnum.QUEUED);
       expect(results).toHaveLength(1);
-      expect(results[0].metadata.schemaVersion).toBe(1);
+      expect(results[0].metadata.schemaVersion).toBe(ANNOTATION_SCHEMA_VERSION);
     });
   });
 

--- a/packages/domscribe-transform/src/core/injector.style-source.spec.ts
+++ b/packages/domscribe-transform/src/core/injector.style-source.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * End-to-end integration tests for the build-time `styleSource` capture
+ * pipeline (RFC 0001).
+ *
+ * These tests drive the real `BabelParser` through the injector so the full
+ * AST → manifest path is exercised. The `captureStyles` flag is the only
+ * thing differentiating these from the existing injector unit tests; with
+ * the flag off (default), no `styleSource` is attached and behavior matches
+ * the v0 baseline.
+ *
+ * @module @domscribe/transform/core/injector.style-source.spec
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { DomscribeInjector } from './injector.js';
+import { BabelParser } from '../parsers/babel/babel.parser.js';
+import type { IDGenerator } from '@domscribe/manifest';
+
+function createIdGenerator(): IDGenerator {
+  let counter = 0;
+  return {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    getStableId: vi.fn().mockImplementation(() => `id_${counter++}`),
+    getFileHash: vi.fn().mockReturnValue('deadbeefcafebabe'),
+    saveCache: vi.fn(),
+  };
+}
+
+describe('Injector with captureStyles flag', () => {
+  it('does not attach styleSource when the flag is off (default)', () => {
+    const parser = new BabelParser();
+    const injector = new DomscribeInjector(parser, createIdGenerator());
+
+    const source = 'const App = () => <div className="p-4 bg-blue-500" />;';
+    const result = injector.inject(source, { sourceFile: '/src/App.tsx' });
+
+    expect(result.manifestEntries).toHaveLength(1);
+    expect(result.manifestEntries[0].styleSource).toBeUndefined();
+  });
+
+  it('attaches className tokens to manifest entries when the flag is on', () => {
+    const parser = new BabelParser();
+    const injector = new DomscribeInjector(parser, createIdGenerator(), {
+      captureStyles: true,
+    });
+
+    const source = 'const App = () => <div className="p-4 bg-blue-500" />;';
+    const result = injector.inject(source, { sourceFile: '/src/App.tsx' });
+
+    expect(result.manifestEntries).toHaveLength(1);
+    const styleSource = result.manifestEntries[0].styleSource;
+    expect(styleSource).toBeDefined();
+    expect(styleSource?.className).toBe('p-4 bg-blue-500');
+    expect(styleSource?.classes).toEqual(['p-4', 'bg-blue-500']);
+    expect(styleSource?.cssInJs).toBeUndefined();
+  });
+
+  it('walks clsx helpers and emits token union from all static branches', () => {
+    const parser = new BabelParser();
+    const injector = new DomscribeInjector(parser, createIdGenerator(), {
+      captureStyles: true,
+    });
+
+    const source = `
+      const App = (props) =>
+        <button className={clsx("p-4", props.active && "bg-blue-500", "rounded")} />;
+    `;
+    const result = injector.inject(source, { sourceFile: '/src/App.tsx' });
+
+    const styleSource = result.manifestEntries[0].styleSource;
+    expect(styleSource?.classes).toEqual(['p-4', 'bg-blue-500', 'rounded']);
+    // Union — not a literal string — so className stays undefined.
+    expect(styleSource?.className).toBeUndefined();
+  });
+
+  it('links a JSX tag to its locally-declared styled-component source block', () => {
+    const parser = new BabelParser();
+    const injector = new DomscribeInjector(parser, createIdGenerator(), {
+      captureStyles: true,
+    });
+
+    const source = [
+      "import styled from 'styled-components';",
+      'const Card = styled.div`',
+      '  padding: 1rem;',
+      '  background: white;',
+      '`;',
+      'const App = () => <Card />;',
+    ].join('\n');
+    const result = injector.inject(source, { sourceFile: '/src/Card.tsx' });
+
+    const styleSourceForCard = result.manifestEntries.find(
+      (e) => e.tagName === 'Card',
+    )?.styleSource;
+    expect(styleSourceForCard).toBeDefined();
+    expect(styleSourceForCard?.cssInJs?.kind).toBe('styled-tag');
+    expect(styleSourceForCard?.cssInJs?.library).toBe('styled-components');
+    expect(styleSourceForCard?.cssInJs?.blockText).toContain('padding: 1rem');
+    expect(styleSourceForCard?.cssInJs?.file).toBe('/src/Card.tsx');
+  });
+
+  it('omits styleSource on elements with no className and no styled binding', () => {
+    const parser = new BabelParser();
+    const injector = new DomscribeInjector(parser, createIdGenerator(), {
+      captureStyles: true,
+    });
+
+    const source = 'const App = () => <div id="root"><span>hi</span></div>;';
+    const result = injector.inject(source, { sourceFile: '/src/App.tsx' });
+
+    // Manifest entries should exist but with no styleSource attached —
+    // keeps payloads compact for the common case.
+    expect(result.manifestEntries).toHaveLength(2);
+    expect(result.manifestEntries[0].styleSource).toBeUndefined();
+    expect(result.manifestEntries[1].styleSource).toBeUndefined();
+  });
+
+  it('extracts tokens from a no-interpolation template literal', () => {
+    const parser = new BabelParser();
+    const injector = new DomscribeInjector(parser, createIdGenerator(), {
+      captureStyles: true,
+    });
+
+    const source = 'const App = () => <div className={`p-4 bg-blue-500`} />;';
+    const result = injector.inject(source, { sourceFile: '/src/App.tsx' });
+
+    const styleSource = result.manifestEntries[0].styleSource;
+    expect(styleSource?.className).toBe('p-4 bg-blue-500');
+    expect(styleSource?.classes).toEqual(['p-4', 'bg-blue-500']);
+  });
+
+  it('captures static segments when a template literal has interpolations', () => {
+    const parser = new BabelParser();
+    const injector = new DomscribeInjector(parser, createIdGenerator(), {
+      captureStyles: true,
+    });
+
+    const source =
+      'const App = (p) => <div className={`p-4 ${p.variant} bg-blue-500`} />;';
+    const result = injector.inject(source, { sourceFile: '/src/App.tsx' });
+
+    const styleSource = result.manifestEntries[0].styleSource;
+    expect(styleSource?.className).toBeUndefined();
+    expect(styleSource?.classes).toEqual(['p-4', 'bg-blue-500']);
+  });
+});

--- a/packages/domscribe-transform/src/core/injector.ts
+++ b/packages/domscribe-transform/src/core/injector.ts
@@ -17,13 +17,23 @@
 import MagicString from 'magic-string';
 import type { ParserInterface } from '../parsers/parser.interface.js';
 import { SourceLocation } from '../parsers/types.js';
-import { PATHS, type ManifestEntry } from '@domscribe/core';
+import {
+  PATHS,
+  type CssInJsSourceLocation,
+  type ManifestEntry,
+} from '@domscribe/core';
 import {
   InjectParams,
   InjectorOptions,
   InjectorResult,
   InjectorMetrics,
 } from './types.js';
+import {
+  buildStyleSource,
+  collectCssInJsDeclarations,
+  extractClassNameFromJSX,
+  resolveTagToBindingName,
+} from './style-extractor.js';
 import { SourceMapConsumer } from 'source-map';
 import { IDStabilizer, type IDGenerator } from '@domscribe/manifest';
 import path from 'path';
@@ -39,6 +49,7 @@ export class DomscribeInjector<TParseResult = unknown, TElement = unknown> {
   ) {
     this.options = {
       debug: options?.debug ?? false,
+      captureStyles: options?.captureStyles ?? false,
     };
   }
 
@@ -127,6 +138,14 @@ export class DomscribeInjector<TParseResult = unknown, TElement = unknown> {
     // Generate manifest entries
     const manifestEntries: ManifestEntry[] = [];
 
+    // Build the file-level CSS-in-JS declaration map once per inject() call
+    // so per-element lookups stay O(1). Skip when style capture is off so
+    // we don't pay for the extra walk in the default-off case.
+    const cssInJsByBinding: Map<string, CssInJsSourceLocation> = this.options
+      .captureStyles
+      ? collectCssInJsDeclarations(ast, source, sourceFile)
+      : new Map();
+
     // Process each element
     for (const element of elements) {
       // Skip if element already has data-ds attribute
@@ -184,6 +203,17 @@ export class DomscribeInjector<TParseResult = unknown, TElement = unknown> {
           end,
           tagName,
         };
+
+        if (this.options.captureStyles) {
+          const classNameInfo = extractClassNameFromJSX(element);
+          const cssInJs = cssInJsByBinding.get(
+            resolveTagToBindingName(tagName),
+          );
+          const styleSource = buildStyleSource(classNameInfo, cssInJs);
+          if (styleSource) {
+            entry.styleSource = styleSource;
+          }
+        }
 
         manifestEntries.push(entry);
         metrics.elementsInjected++;

--- a/packages/domscribe-transform/src/core/style-extractor.ts
+++ b/packages/domscribe-transform/src/core/style-extractor.ts
@@ -1,0 +1,670 @@
+/**
+ * Build-time style attribution extractor.
+ *
+ * Runs on top of the existing AST visit performed by the injector. For each
+ * JSX opening element, extracts:
+ *
+ *  - `className` (when statically resolvable to a single string literal or
+ *    no-interpolation template literal)
+ *  - `classes`   (best-effort utility-class tokens reachable through
+ *    clsx/cn/tw/classNames/twMerge/cva helpers, template literals,
+ *    conditional expressions, logical expressions, object expressions, and
+ *    array expressions)
+ *
+ * Separately, a one-shot pass over the module's top-level statements
+ * collects every `const X = styled.Y\`...\`;` / `const X = styled(Y)\`...\`;`
+ * / `const X = css\`...\`;` declaration so a JSX element whose tag binds to
+ * a locally-declared styled component can be linked back to its source
+ * block.
+ *
+ * Operates on either Babel (`StringLiteral`) or Acorn (`Literal`) AST shapes
+ * via duck typing — the type names overlap enough that one walker handles
+ * both. Parser-specific node helpers are passed in by the caller.
+ *
+ * @module @domscribe/transform/core/style-extractor
+ */
+
+import type { CssInJsSourceLocation, StyleSource } from '@domscribe/core';
+
+/**
+ * Identifiers conventionally used as className helper functions.
+ *
+ * The list is intentionally short — every entry needs to be a known
+ * "concatenate strings" helper. Adding `clsx-like` is fine; adding
+ * `tailwind-merge`-style functions that perform substitution is risky
+ * because they can drop tokens, but we still capture pre-merge tokens
+ * (the agent can read the source to see the helper).
+ */
+const CLASSNAME_HELPER_NAMES = new Set([
+  'clsx',
+  'cn',
+  'classNames',
+  'tw',
+  'twMerge',
+  'cva',
+]);
+
+/**
+ * Maximum bytes of `blockText` we capture per CSS-in-JS declaration. Aligns
+ * with the existing ≤4 KB per-element serialization budget — a single
+ * styled block much larger than this is an outlier and the agent can read
+ * the source directly.
+ */
+const CSS_IN_JS_BLOCK_BYTE_BUDGET = 4 * 1024;
+
+/**
+ * Split a className string into utility-class tokens.
+ *
+ * Whitespace-separated; ignores empty tokens. No deduplication — the order
+ * a user wrote tokens in often matters (e.g. Tailwind `last-of-type`
+ * overrides) and downstream consumers can dedupe if they need to.
+ */
+export function parseClassNameString(value: string): string[] {
+  return value
+    .trim()
+    .split(/\s+/u)
+    .filter((token) => token.length > 0);
+}
+
+interface MinimalNode {
+  type?: string;
+  [key: string]: unknown;
+}
+
+type AstNode = MinimalNode | null | undefined;
+
+interface StaticEvaluation {
+  /** True when every reachable branch resolves to a string at compile time. */
+  fullyStatic: boolean;
+  /** Tokens collected from string-typed leaves (best-effort union). */
+  tokens: string[];
+  /**
+   * If `fullyStatic` and the value is a single string, this is that string
+   * (used to populate `styleSource.className`). Undefined otherwise.
+   */
+  literal?: string;
+}
+
+const EMPTY: StaticEvaluation = { fullyStatic: false, tokens: [] };
+
+function asString(node: AstNode): string | undefined {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+  const value = (node as MinimalNode).value;
+  if (typeof value === 'string') {
+    return value;
+  }
+  return undefined;
+}
+
+function unionStatic(branches: StaticEvaluation[]): StaticEvaluation {
+  // Branch union: result is fully static only if every branch resolves to a
+  // string. We never collapse into a single literal because we don't know
+  // which branch the runtime will pick.
+  const tokens = branches.flatMap((b) => b.tokens);
+  return {
+    fullyStatic: branches.every((b) => b.fullyStatic),
+    tokens,
+  };
+}
+
+function concatStatic(branches: StaticEvaluation[]): StaticEvaluation {
+  // Sequential concatenation (template literals, clsx args): all-or-nothing
+  // for `fullyStatic`. If every branch resolves to a literal string, we can
+  // produce a concatenated literal for `className`.
+  const tokens = branches.flatMap((b) => b.tokens);
+  const allLiteral = branches.every((b) => typeof b.literal === 'string');
+  return {
+    fullyStatic: branches.every((b) => b.fullyStatic),
+    tokens,
+    literal: allLiteral
+      ? branches
+          .map((b) => b.literal ?? '')
+          .join(' ')
+          .replace(/\s+/g, ' ')
+          .trim()
+      : undefined,
+  };
+}
+
+function evalStringLiteral(node: AstNode): StaticEvaluation | undefined {
+  // Babel uses `StringLiteral`; Acorn uses `Literal` with a string `value`.
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+  const type = (node as MinimalNode).type;
+  if (type === 'StringLiteral') {
+    const value = asString(node) ?? '';
+    return {
+      fullyStatic: true,
+      tokens: parseClassNameString(value),
+      literal: value,
+    };
+  }
+  if (type === 'Literal') {
+    const value = (node as MinimalNode).value;
+    if (typeof value === 'string') {
+      return {
+        fullyStatic: true,
+        tokens: parseClassNameString(value),
+        literal: value,
+      };
+    }
+  }
+  return undefined;
+}
+
+function evalTemplateLiteral(node: AstNode): StaticEvaluation | undefined {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+  if ((node as MinimalNode).type !== 'TemplateLiteral') {
+    return undefined;
+  }
+  const quasis = ((node as MinimalNode).quasis ?? []) as MinimalNode[];
+  const expressions = ((node as MinimalNode).expressions ?? []) as AstNode[];
+  const branches: StaticEvaluation[] = [];
+
+  for (let i = 0; i < quasis.length; i++) {
+    const quasi = quasis[i];
+    const cooked =
+      (((quasi as MinimalNode).value as MinimalNode | undefined)?.cooked as
+        | string
+        | undefined) ?? '';
+    branches.push({
+      fullyStatic: true,
+      tokens: parseClassNameString(cooked),
+      literal: cooked,
+    });
+    if (i < expressions.length) {
+      branches.push(evaluateExpression(expressions[i]));
+    }
+  }
+  return concatStatic(branches);
+}
+
+function getCalleeName(callee: AstNode): string | undefined {
+  if (!callee || typeof callee !== 'object') {
+    return undefined;
+  }
+  const type = (callee as MinimalNode).type;
+  if (type === 'Identifier') {
+    const name = (callee as MinimalNode).name;
+    return typeof name === 'string' ? name : undefined;
+  }
+  // MemberExpression like `utils.cn(...)` — match on the tail identifier.
+  if (type === 'MemberExpression') {
+    const property = (callee as MinimalNode).property as AstNode;
+    if (property && typeof property === 'object') {
+      const name = (property as MinimalNode).name;
+      return typeof name === 'string' ? name : undefined;
+    }
+  }
+  return undefined;
+}
+
+function evalCallExpression(node: AstNode): StaticEvaluation | undefined {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+  if ((node as MinimalNode).type !== 'CallExpression') {
+    return undefined;
+  }
+  const callee = (node as MinimalNode).callee as AstNode;
+  const name = getCalleeName(callee);
+  if (!name || !CLASSNAME_HELPER_NAMES.has(name)) {
+    // Unknown helper — we can't reason about its arguments. Be conservative.
+    return EMPTY;
+  }
+  const args = ((node as MinimalNode).arguments ?? []) as AstNode[];
+  const branches = args.map((arg) => evaluateExpression(arg));
+  // Helper-call branches are unioned: we don't know which args contribute
+  // at runtime (some may evaluate to false/undefined). All-static here is
+  // already weaker than concat — every arg must be statically resolvable.
+  return unionStatic(branches);
+}
+
+function evalConditional(node: AstNode): StaticEvaluation | undefined {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+  if ((node as MinimalNode).type !== 'ConditionalExpression') {
+    return undefined;
+  }
+  const consequent = evaluateExpression(
+    (node as MinimalNode).consequent as AstNode,
+  );
+  const alternate = evaluateExpression(
+    (node as MinimalNode).alternate as AstNode,
+  );
+  return unionStatic([consequent, alternate]);
+}
+
+function evalLogical(node: AstNode): StaticEvaluation | undefined {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+  if ((node as MinimalNode).type !== 'LogicalExpression') {
+    return undefined;
+  }
+  // `cond && 'foo'` / `cond || 'fallback'` / `a ?? 'foo'`: union the
+  // operands that can produce string output. We don't attempt to evaluate
+  // the truthiness of `cond` itself.
+  const left = evaluateExpression((node as MinimalNode).left as AstNode);
+  const right = evaluateExpression((node as MinimalNode).right as AstNode);
+  return unionStatic([left, right]);
+}
+
+function evalArray(node: AstNode): StaticEvaluation | undefined {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+  if ((node as MinimalNode).type !== 'ArrayExpression') {
+    return undefined;
+  }
+  const elements = ((node as MinimalNode).elements ?? []) as AstNode[];
+  return unionStatic(elements.map((el) => evaluateExpression(el)));
+}
+
+function evalObject(node: AstNode): StaticEvaluation | undefined {
+  if (!node || typeof node !== 'object') {
+    return undefined;
+  }
+  if ((node as MinimalNode).type !== 'ObjectExpression') {
+    return undefined;
+  }
+  // clsx({ 'foo': cond, 'bar baz': true }) — keys are token strings, values
+  // are runtime-evaluated. Capture string keys as candidate tokens.
+  const properties = ((node as MinimalNode).properties ?? []) as MinimalNode[];
+  const tokens: string[] = [];
+  for (const prop of properties) {
+    if (prop?.type === 'ObjectProperty' || prop?.type === 'Property') {
+      const key = prop['key'] as AstNode;
+      if (key && typeof key === 'object') {
+        const keyType = (key as MinimalNode).type;
+        if (keyType === 'StringLiteral' || keyType === 'Literal') {
+          const value = asString(key);
+          if (typeof value === 'string') {
+            tokens.push(...parseClassNameString(value));
+          }
+        }
+        // Identifier keys (without computed:) become token names — but they
+        // are JS identifiers, not utility classes, so we skip them.
+      }
+    }
+  }
+  return { fullyStatic: false, tokens };
+}
+
+function evaluateExpression(node: AstNode): StaticEvaluation {
+  if (!node || typeof node !== 'object') {
+    return EMPTY;
+  }
+  // JSXExpressionContainer is a transparent wrapper around its expression.
+  if ((node as MinimalNode).type === 'JSXExpressionContainer') {
+    return evaluateExpression((node as MinimalNode).expression as AstNode);
+  }
+  return (
+    evalStringLiteral(node) ??
+    evalTemplateLiteral(node) ??
+    evalCallExpression(node) ??
+    evalConditional(node) ??
+    evalLogical(node) ??
+    evalArray(node) ??
+    evalObject(node) ??
+    EMPTY
+  );
+}
+
+interface JSXAttributeLike {
+  type?: string;
+  name?: { name?: string; type?: string } | string;
+  value?: AstNode;
+}
+
+function getJsxAttributeName(attr: JSXAttributeLike): string | undefined {
+  if (!attr || typeof attr.name === 'undefined') {
+    return undefined;
+  }
+  if (typeof attr.name === 'string') {
+    return attr.name;
+  }
+  if (typeof attr.name === 'object' && attr.name !== null) {
+    const n = attr.name.name;
+    return typeof n === 'string' ? n : undefined;
+  }
+  return undefined;
+}
+
+function asElementWithAttributes(
+  element: unknown,
+): { attributes?: JSXAttributeLike[] } | undefined {
+  if (!element || typeof element !== 'object') return undefined;
+  const attrs = (element as { attributes?: unknown }).attributes;
+  if (attrs === undefined) {
+    return { attributes: undefined };
+  }
+  if (Array.isArray(attrs)) {
+    return { attributes: attrs as JSXAttributeLike[] };
+  }
+  return undefined;
+}
+
+/**
+ * Extract build-time className information from a JSX opening element.
+ *
+ * Returns `undefined` if the element has no `className` attribute (no point
+ * recording an empty `styleSource`). Otherwise returns the best-effort
+ * static evaluation:
+ *
+ *  - String literal → fully static, `className` populated, `classes` parsed.
+ *  - Template literal without interpolations → as above.
+ *  - clsx/cn/tw/classNames/twMerge/cva call → tokens reachable through any
+ *    argument branch, `className` only when every branch is a literal.
+ *  - Conditional / logical / array / object → token union, `className`
+ *    undefined.
+ *  - Anything else (function call, member expression, spread) →
+ *    `classes: []` and `className` undefined, signalling "computed at
+ *    runtime; read source directly".
+ */
+export function extractClassNameFromJSX(
+  element: unknown,
+): { className?: string; classes?: string[] } | undefined {
+  const narrowed = asElementWithAttributes(element);
+  if (!narrowed || !Array.isArray(narrowed.attributes)) {
+    return undefined;
+  }
+
+  const attr = narrowed.attributes.find((a): a is JSXAttributeLike => {
+    if (!a || typeof a !== 'object') return false;
+    if (a.type !== 'JSXAttribute') return false;
+    return getJsxAttributeName(a) === 'className';
+  });
+
+  if (!attr) {
+    return undefined;
+  }
+
+  // Attribute with no value: `<div className />` — degenerate; treat as
+  // empty.
+  if (attr.value === null || attr.value === undefined) {
+    return { className: '', classes: [] };
+  }
+
+  const evaluation = evaluateExpression(attr.value as AstNode);
+  const result: { className?: string; classes?: string[] } = {};
+  if (typeof evaluation.literal === 'string') {
+    result.className = evaluation.literal;
+  }
+  result.classes = evaluation.tokens;
+  return result;
+}
+
+interface DeclarationLocation {
+  line: number;
+  column: number;
+  startOffset?: number;
+  endOffset?: number;
+}
+
+function getNodeLocation(node: AstNode): DeclarationLocation | undefined {
+  if (!node || typeof node !== 'object') return undefined;
+  const loc = (node as MinimalNode).loc as
+    | { start?: { line?: number; column?: number } }
+    | undefined;
+  if (!loc?.start || typeof loc.start.line !== 'number') {
+    return undefined;
+  }
+  const start = (node as MinimalNode).start;
+  const end = (node as MinimalNode).end;
+  return {
+    line: loc.start.line,
+    column: typeof loc.start.column === 'number' ? loc.start.column : 0,
+    startOffset: typeof start === 'number' ? start : undefined,
+    endOffset: typeof end === 'number' ? end : undefined,
+  };
+}
+
+function extractTemplateBlockText(
+  node: AstNode,
+  source: string,
+): string | undefined {
+  if (!node || typeof node !== 'object') return undefined;
+  if ((node as MinimalNode).type !== 'TaggedTemplateExpression') {
+    return undefined;
+  }
+  const quasi = (node as MinimalNode).quasi as AstNode;
+  if (!quasi || typeof quasi !== 'object') return undefined;
+  const start = (quasi as MinimalNode).start;
+  const end = (quasi as MinimalNode).end;
+  if (typeof start !== 'number' || typeof end !== 'number') {
+    return undefined;
+  }
+  return source.slice(start, end).slice(0, CSS_IN_JS_BLOCK_BYTE_BUDGET);
+}
+
+interface CssInJsMatch {
+  kind: 'styled-tag' | 'styled-call' | 'css-template';
+  library?: 'styled-components' | 'emotion' | 'unknown';
+}
+
+function classifyTaggedTemplate(node: AstNode): CssInJsMatch | undefined {
+  // Examines a TaggedTemplateExpression's tag to decide whether this is a
+  // styled-components / emotion declaration we should record.
+  if (!node || typeof node !== 'object') return undefined;
+  if ((node as MinimalNode).type !== 'TaggedTemplateExpression') {
+    return undefined;
+  }
+  const tag = (node as MinimalNode).tag as AstNode;
+  if (!tag || typeof tag !== 'object') return undefined;
+
+  const tagType = (tag as MinimalNode).type;
+
+  // `styled.div\`...\`` / `styled.button\`...\``
+  if (tagType === 'MemberExpression') {
+    const object = (tag as MinimalNode).object as AstNode;
+    if (object && typeof object === 'object') {
+      const name = (object as MinimalNode).name;
+      if (name === 'styled') {
+        return { kind: 'styled-tag', library: 'unknown' };
+      }
+    }
+  }
+
+  // `styled(Component)\`...\``
+  if (tagType === 'CallExpression') {
+    const callee = (tag as MinimalNode).callee as AstNode;
+    if (callee && typeof callee === 'object') {
+      const calleeName = (callee as MinimalNode).name;
+      if (calleeName === 'styled') {
+        return { kind: 'styled-call', library: 'unknown' };
+      }
+    }
+  }
+
+  // `css\`...\`` — emotion-style top-level
+  if (tagType === 'Identifier') {
+    const name = (tag as MinimalNode).name;
+    if (name === 'css') {
+      return { kind: 'css-template', library: 'emotion' };
+    }
+  }
+
+  return undefined;
+}
+
+function getBindingIdentifiersFromVariableDeclarator(
+  declarator: AstNode,
+): string[] {
+  if (!declarator || typeof declarator !== 'object') return [];
+  const id = (declarator as MinimalNode).id as AstNode;
+  if (!id || typeof id !== 'object') return [];
+  if ((id as MinimalNode).type === 'Identifier') {
+    const name = (id as MinimalNode).name;
+    return typeof name === 'string' ? [name] : [];
+  }
+  return [];
+}
+
+/**
+ * Walk a parsed module and collect every top-level CSS-in-JS declaration
+ * keyed by its bound identifier name.
+ *
+ * Handles three shapes (per RFC 0001):
+ *  - `const X = styled.div\`...\`;`
+ *  - `const X = styled(Component)\`...\`;`
+ *  - `const X = css\`...\`;`
+ *
+ * `library` detection from imports is intentionally minimal — we look at
+ * the import source so the agent gets a hint, but classification is not
+ * required for correctness. Anything ambiguous is recorded as `'unknown'`.
+ *
+ * Operates against either Babel or Acorn AST shapes via duck typing.
+ */
+export function collectCssInJsDeclarations(
+  ast: unknown,
+  source: string,
+  sourceFile: string,
+): Map<string, CssInJsSourceLocation> {
+  const map = new Map<string, CssInJsSourceLocation>();
+  const importedLibrary = detectStyledLibraryFromImports(ast);
+
+  const program = unwrapProgram(ast);
+  if (!program) return map;
+
+  for (const statement of program) {
+    // const X = styled.foo`...`;  /  let X = ...;  /  var X = ...;
+    const declarations = getVariableDeclarations(statement);
+    for (const declarator of declarations) {
+      const init = (declarator as MinimalNode).init as AstNode;
+      const match = classifyTaggedTemplate(init);
+      if (!match) continue;
+
+      const names = getBindingIdentifiersFromVariableDeclarator(declarator);
+      if (names.length === 0) continue;
+
+      const loc = getNodeLocation(init);
+      if (!loc) continue;
+
+      const blockText = extractTemplateBlockText(init, source) ?? '';
+      const library =
+        match.library === 'unknown' && importedLibrary
+          ? importedLibrary
+          : (match.library ?? 'unknown');
+
+      const entry: CssInJsSourceLocation = {
+        file: sourceFile,
+        line: loc.line,
+        column: loc.column,
+        blockText,
+        library,
+        kind: match.kind,
+      };
+
+      for (const name of names) {
+        map.set(name, entry);
+      }
+    }
+  }
+
+  return map;
+}
+
+function unwrapProgram(ast: unknown): MinimalNode[] | undefined {
+  if (!ast || typeof ast !== 'object') return undefined;
+  const node = ast as MinimalNode;
+  if (
+    node.type === 'File' &&
+    node.program &&
+    typeof node.program === 'object'
+  ) {
+    const body = (node.program as MinimalNode).body;
+    return Array.isArray(body) ? (body as MinimalNode[]) : undefined;
+  }
+  if (node.type === 'Program') {
+    return Array.isArray(node.body) ? (node.body as MinimalNode[]) : undefined;
+  }
+  // Some callers pass the Program directly.
+  if (Array.isArray(node.body)) {
+    return node.body as MinimalNode[];
+  }
+  return undefined;
+}
+
+function getVariableDeclarations(statement: MinimalNode): MinimalNode[] {
+  // VariableDeclaration directly at top level.
+  if (statement.type === 'VariableDeclaration') {
+    return Array.isArray(statement.declarations)
+      ? (statement.declarations as MinimalNode[])
+      : [];
+  }
+  // ExportNamedDeclaration wrapping a VariableDeclaration.
+  if (statement.type === 'ExportNamedDeclaration') {
+    const decl = statement.declaration as MinimalNode | undefined;
+    if (decl?.type === 'VariableDeclaration') {
+      return Array.isArray(decl.declarations)
+        ? (decl.declarations as MinimalNode[])
+        : [];
+    }
+  }
+  return [];
+}
+
+function detectStyledLibraryFromImports(
+  ast: unknown,
+): 'styled-components' | 'emotion' | undefined {
+  const program = unwrapProgram(ast);
+  if (!program) return undefined;
+  for (const statement of program) {
+    if (statement?.type !== 'ImportDeclaration') continue;
+    const sourceNode = statement['source'] as MinimalNode | undefined;
+    const sourceValue = sourceNode?.value;
+    if (typeof sourceValue !== 'string') continue;
+    if (sourceValue === 'styled-components') return 'styled-components';
+    if (sourceValue.startsWith('@emotion/')) return 'emotion';
+  }
+  return undefined;
+}
+
+/**
+ * Assemble a `StyleSource` for one JSX opening element, given the element's
+ * className extraction and the file-level CSS-in-JS declaration map.
+ *
+ * Returns `undefined` when there's nothing worth recording (no className
+ * attribute and no styled-component binding) — keeps manifest entries
+ * compact for the common case (plain `<div>` with no styling).
+ */
+export function buildStyleSource(
+  classNameInfo: { className?: string; classes?: string[] } | undefined,
+  cssInJs: CssInJsSourceLocation | undefined,
+): StyleSource | undefined {
+  if (!classNameInfo && !cssInJs) return undefined;
+  const out: StyleSource = {};
+  if (classNameInfo) {
+    if (typeof classNameInfo.className === 'string') {
+      out.className = classNameInfo.className;
+    }
+    if (classNameInfo.classes) {
+      out.classes = classNameInfo.classes;
+    }
+  }
+  if (cssInJs) {
+    out.cssInJs = cssInJs;
+  }
+  return out;
+}
+
+/**
+ * Resolve a JSX tag name down to the locally-declared styled-component
+ * binding (if any) for `collectCssInJsDeclarations()` lookup.
+ *
+ * `<StyledButton>` → `StyledButton`. Member-expression tags like
+ * `<UI.Card.Body>` are looked up under their root identifier (`UI`) which
+ * never matches a `styled.x\`\`` binding, so they naturally yield no match.
+ */
+export function resolveTagToBindingName(tagName: string): string {
+  const dotIndex = tagName.indexOf('.');
+  if (dotIndex === -1) return tagName;
+  return tagName.slice(0, dotIndex);
+}

--- a/packages/domscribe-transform/src/core/types.ts
+++ b/packages/domscribe-transform/src/core/types.ts
@@ -16,6 +16,19 @@ export interface InjectorOptions {
    * @default false
    */
   debug?: boolean;
+
+  /**
+   * Capture build-time style attribution (`styleSource`) on every manifest
+   * entry. When `true`, the injector extracts className tokens and
+   * styled-component source-block locations on the same AST visit that
+   * injects `data-ds` attributes.
+   *
+   * Bundler plugins read `domscribe.config.captureStyles` and propagate it
+   * here. Default-off in v0.x per RFC 0001 reversibility plan.
+   *
+   * @default false
+   */
+  captureStyles?: boolean;
 }
 
 /**

--- a/packages/domscribe-transform/src/plugins/turbopack/turbopack.loader.ts
+++ b/packages/domscribe-transform/src/plugins/turbopack/turbopack.loader.ts
@@ -71,7 +71,7 @@ async function doInit(
   rootContext: string,
   options: TurbopackLoaderOptions,
 ): Promise<void> {
-  const { debug = false, relay = {} } = options;
+  const { debug = false, relay = {}, captureStyles = false } = options;
 
   if (debug) {
     console.log(`${LOG_PREFIX} Initializing singletons...`);
@@ -81,7 +81,10 @@ async function doInit(
   ManifestWriter.getInstance(rootContext, { debug });
 
   // Initialize injector registry
-  const injectorRegistry = InjectorRegistry.getInstance(rootContext, { debug });
+  const injectorRegistry = InjectorRegistry.getInstance(rootContext, {
+    debug,
+    captureStyles,
+  });
   await injectorRegistry.initialize();
 
   // Initialize stats

--- a/packages/domscribe-transform/src/plugins/turbopack/types.ts
+++ b/packages/domscribe-transform/src/plugins/turbopack/types.ts
@@ -58,6 +58,14 @@ export interface TurbopackLoaderOptions {
    * Falls back to `@domscribe/next/auto-init` when omitted.
    */
   autoInitPath?: string;
+
+  /**
+   * Capture build-time style attribution (`styleSource`) on every manifest
+   * entry. See `VitePluginOptions.captureStyles` for details.
+   *
+   * @default false
+   */
+  captureStyles?: boolean;
 }
 
 /**

--- a/packages/domscribe-transform/src/plugins/vite/types.ts
+++ b/packages/domscribe-transform/src/plugins/vite/types.ts
@@ -54,4 +54,16 @@ export interface VitePluginOptions {
    * root differs from the project root (e.g., Nuxt with a custom `srcDir`).
    */
   rootDir?: string;
+
+  /**
+   * Capture build-time style attribution (`styleSource`) on every manifest
+   * entry. Extracts className tokens and styled-component source-block
+   * locations on the same AST visit that injects `data-ds`.
+   *
+   * Per RFC 0001 the feature flag defaults off in v0.x; opt in to give
+   * agents single-round-trip styling context.
+   *
+   * @default false
+   */
+  captureStyles?: boolean;
 }

--- a/packages/domscribe-transform/src/plugins/vite/vite.plugin.spec.ts
+++ b/packages/domscribe-transform/src/plugins/vite/vite.plugin.spec.ts
@@ -388,6 +388,7 @@ describe('domscribe Vite plugin', () => {
         '/test/workspace',
         {
           debug: true,
+          captureStyles: false,
         },
       );
     });

--- a/packages/domscribe-transform/src/plugins/vite/vite.plugin.ts
+++ b/packages/domscribe-transform/src/plugins/vite/vite.plugin.ts
@@ -96,6 +96,7 @@ export function domscribe(options: VitePluginOptions = {}): Plugin {
     relay: relayOptions = {},
     overlay: overlayOption = true,
     rootDir,
+    captureStyles = false,
   } = options;
   const filter = createFilter(include, exclude);
 
@@ -181,7 +182,10 @@ export function domscribe(options: VitePluginOptions = {}): Plugin {
       // Note: ManifestWriter.getInstance() calls initialize() internally via constructor
       writer = ManifestWriter.getInstance(rootContext, { debug });
 
-      injectorRegistry = InjectorRegistry.getInstance(rootContext, { debug });
+      injectorRegistry = InjectorRegistry.getInstance(rootContext, {
+        debug,
+        captureStyles,
+      });
       await injectorRegistry.initialize();
 
       stats = TransformStats.getInstance(rootContext);

--- a/packages/domscribe-transform/src/plugins/webpack/types.ts
+++ b/packages/domscribe-transform/src/plugins/webpack/types.ts
@@ -58,4 +58,12 @@ export interface WebpackPluginOptions {
    * @default true
    */
   overlay?: boolean | OverlayPluginOptions;
+
+  /**
+   * Capture build-time style attribution (`styleSource`) on every manifest
+   * entry. See `VitePluginOptions.captureStyles` for details.
+   *
+   * @default false
+   */
+  captureStyles?: boolean;
 }

--- a/packages/domscribe-transform/src/plugins/webpack/webpack.plugin.spec.ts
+++ b/packages/domscribe-transform/src/plugins/webpack/webpack.plugin.spec.ts
@@ -433,7 +433,7 @@ describe('DomscribeWebpackPlugin', () => {
       // Assert
       expect(mockInjectorRegistryGetInstance).toHaveBeenCalledWith(
         '/test/workspace',
-        { debug: false },
+        { debug: false, captureStyles: false },
       );
       expect(mockInjectorRegistry.initialize).toHaveBeenCalledTimes(1);
     });

--- a/packages/domscribe-transform/src/plugins/webpack/webpack.plugin.ts
+++ b/packages/domscribe-transform/src/plugins/webpack/webpack.plugin.ts
@@ -27,6 +27,7 @@ interface ResolvedOptions {
   relay: RelayPluginOptions;
   overlayEnabled: boolean;
   overlayOptions: OverlayPluginOptions;
+  captureStyles: boolean;
 }
 
 /**
@@ -57,6 +58,7 @@ export class DomscribeWebpackPlugin {
       enabled = !isProduction,
       relay = {},
       overlay = true,
+      captureStyles = false,
     } = options;
 
     // Resolve overlay options
@@ -70,6 +72,7 @@ export class DomscribeWebpackPlugin {
       relay,
       overlayEnabled,
       overlayOptions,
+      captureStyles,
     };
   }
 
@@ -155,6 +158,7 @@ export class DomscribeWebpackPlugin {
 
       this.injectorRegistry = InjectorRegistry.getInstance(rootContext, {
         debug: this.options.debug,
+        captureStyles: this.options.captureStyles ?? false,
       });
       await this.injectorRegistry.initialize();
 

--- a/packages/domscribe-transform/test/className-corpus/className-extractor.spec.ts
+++ b/packages/domscribe-transform/test/className-corpus/className-extractor.spec.ts
@@ -1,0 +1,435 @@
+/**
+ * Real-world className extractor corpus.
+ *
+ * This suite exercises `extractClassNameFromJSX` against the long-tail
+ * patterns the RFC 0001 review flagged. The extractor is parser-agnostic
+ * via duck typing — these tests drive it with Babel ASTs because Babel
+ * handles both JS and TS uniformly, which is what production codebases
+ * actually ship.
+ *
+ * Each test names the pattern it covers; adding new patterns means adding
+ * a new case here (and, when the production extractor needs a code change,
+ * a corresponding update to `style-extractor.ts`).
+ *
+ * @module @domscribe/transform/test/className-corpus
+ */
+import { describe, expect, it } from 'vitest';
+import { parse } from '@babel/parser';
+import type {
+  Node,
+  JSXOpeningElement,
+  ExpressionStatement,
+} from '@babel/types';
+import { isJSXElement } from '@babel/types';
+import {
+  collectCssInJsDeclarations,
+  extractClassNameFromJSX,
+  parseClassNameString,
+  resolveTagToBindingName,
+} from '../../src/core/style-extractor.js';
+
+/**
+ * Parse a JSX expression and return the first JSX opening element found.
+ * Tests focus on one element per snippet to keep assertions tight.
+ */
+function parseOpening(snippet: string): JSXOpeningElement {
+  const ast = parse(`(${snippet});`, {
+    sourceType: 'module',
+    plugins: ['typescript', 'jsx'],
+    ranges: true,
+  });
+  const stmt = ast.program.body[0] as ExpressionStatement;
+  const expr = stmt.expression as unknown as Node;
+  if (isJSXElement(expr)) {
+    return expr.openingElement;
+  }
+  // ParenthesizedExpression wrapper (`(<div/>);`) on certain babel configs.
+  type ParenLike = { type: string; expression?: Node };
+  const parenLike = expr as ParenLike;
+  if (parenLike.type === 'ParenthesizedExpression' && parenLike.expression) {
+    const inner = parenLike.expression;
+    if (isJSXElement(inner)) {
+      return inner.openingElement;
+    }
+  }
+  throw new Error('Expected a JSXElement at the top of the snippet');
+}
+
+describe('parseClassNameString', () => {
+  it('splits on whitespace', () => {
+    expect(parseClassNameString('p-4 bg-blue-500 text-white')).toEqual([
+      'p-4',
+      'bg-blue-500',
+      'text-white',
+    ]);
+  });
+
+  it('collapses runs of whitespace and ignores empty tokens', () => {
+    expect(parseClassNameString('  p-4\n\nbg-blue-500\ttext-white  ')).toEqual([
+      'p-4',
+      'bg-blue-500',
+      'text-white',
+    ]);
+  });
+
+  it('returns an empty array for blank input', () => {
+    expect(parseClassNameString('')).toEqual([]);
+    expect(parseClassNameString('   ')).toEqual([]);
+  });
+
+  it('preserves order (last-wins overrides matter in Tailwind)', () => {
+    const tokens = parseClassNameString('px-4 px-2');
+    expect(tokens).toEqual(['px-4', 'px-2']);
+  });
+});
+
+describe('extractClassNameFromJSX — static string-literal', () => {
+  it('extracts a quoted className attribute', () => {
+    const opening = parseOpening('<div className="p-4 bg-blue-500" />');
+
+    const result = extractClassNameFromJSX(opening);
+
+    expect(result).toBeDefined();
+    expect(result?.className).toBe('p-4 bg-blue-500');
+    expect(result?.classes).toEqual(['p-4', 'bg-blue-500']);
+  });
+
+  it('extracts a className wrapped in a JSX expression container', () => {
+    const opening = parseOpening('<div className={"p-4 bg-blue-500"} />');
+
+    const result = extractClassNameFromJSX(opening);
+
+    expect(result?.className).toBe('p-4 bg-blue-500');
+    expect(result?.classes).toEqual(['p-4', 'bg-blue-500']);
+  });
+
+  it('returns undefined when no className attribute is present', () => {
+    const opening = parseOpening('<div id="main" />');
+    expect(extractClassNameFromJSX(opening)).toBeUndefined();
+  });
+
+  it('treats valueless className as empty', () => {
+    const opening = parseOpening('<div className />');
+    const result = extractClassNameFromJSX(opening);
+    expect(result).toBeDefined();
+    expect(result?.classes).toEqual([]);
+  });
+});
+
+describe('extractClassNameFromJSX — template literals', () => {
+  it('returns a static literal for an interpolation-free template', () => {
+    const opening = parseOpening('<div className={`p-4 bg-blue-500`} />');
+
+    const result = extractClassNameFromJSX(opening);
+
+    expect(result?.className).toBe('p-4 bg-blue-500');
+    expect(result?.classes).toEqual(['p-4', 'bg-blue-500']);
+  });
+
+  it('keeps static segments and drops the interpolation', () => {
+    const opening = parseOpening(
+      '<div className={`p-4 ${variant} bg-blue-500`} />',
+    );
+
+    const result = extractClassNameFromJSX(opening);
+
+    // Interpolated portion is runtime-only — `className` cannot be a literal.
+    expect(result?.className).toBeUndefined();
+    // But the static segments remain useful for the agent.
+    expect(result?.classes).toEqual(['p-4', 'bg-blue-500']);
+  });
+});
+
+describe('extractClassNameFromJSX — clsx/cn helpers', () => {
+  it('extracts tokens through a clsx call with string args', () => {
+    const opening = parseOpening(
+      '<div className={clsx("p-4", "bg-blue-500", "text-white")} />',
+    );
+
+    const result = extractClassNameFromJSX(opening);
+
+    expect(result?.classes).toEqual(['p-4', 'bg-blue-500', 'text-white']);
+    // clsx is union-shaped — we cannot collapse args into a single literal.
+    expect(result?.className).toBeUndefined();
+  });
+
+  it('extracts tokens through cn (a clsx alias)', () => {
+    const opening = parseOpening(
+      '<div className={cn("p-4", "bg-blue-500")} />',
+    );
+
+    expect(extractClassNameFromJSX(opening)?.classes).toEqual([
+      'p-4',
+      'bg-blue-500',
+    ]);
+  });
+
+  it('extracts tokens through classNames helper', () => {
+    const opening = parseOpening(
+      '<div className={classNames("p-4", "bg-blue-500")} />',
+    );
+
+    expect(extractClassNameFromJSX(opening)?.classes).toEqual([
+      'p-4',
+      'bg-blue-500',
+    ]);
+  });
+
+  it('extracts tokens through tw / twMerge / cva', () => {
+    const tw = parseOpening('<div className={tw("p-4", "bg-blue-500")} />');
+    const twMerge = parseOpening(
+      '<div className={twMerge("p-4", "bg-blue-500")} />',
+    );
+    const cva = parseOpening('<div className={cva("p-4", "bg-blue-500")} />');
+
+    expect(extractClassNameFromJSX(tw)?.classes).toEqual([
+      'p-4',
+      'bg-blue-500',
+    ]);
+    expect(extractClassNameFromJSX(twMerge)?.classes).toEqual([
+      'p-4',
+      'bg-blue-500',
+    ]);
+    expect(extractClassNameFromJSX(cva)?.classes).toEqual([
+      'p-4',
+      'bg-blue-500',
+    ]);
+  });
+
+  it('walks logical and conditional args inside clsx', () => {
+    const opening = parseOpening(
+      '<div className={clsx("p-4", active && "bg-blue-500", state === "loading" ? "opacity-50" : "opacity-100")} />',
+    );
+
+    const result = extractClassNameFromJSX(opening);
+
+    // Every static branch contributes; runtime conditions don't.
+    expect(result?.classes).toEqual([
+      'p-4',
+      'bg-blue-500',
+      'opacity-50',
+      'opacity-100',
+    ]);
+    expect(result?.className).toBeUndefined();
+  });
+
+  it('walks object-expression args (clsx-style key:condition)', () => {
+    const opening = parseOpening(
+      '<div className={clsx("p-4", { "bg-blue-500": isActive, "text-white": true })} />',
+    );
+
+    const result = extractClassNameFromJSX(opening);
+
+    expect(result?.classes).toEqual(['p-4', 'bg-blue-500', 'text-white']);
+  });
+
+  it('walks array-expression args (clsx-style arrays)', () => {
+    const opening = parseOpening(
+      '<div className={clsx(["p-4", "bg-blue-500"], "text-white")} />',
+    );
+
+    expect(extractClassNameFromJSX(opening)?.classes).toEqual([
+      'p-4',
+      'bg-blue-500',
+      'text-white',
+    ]);
+  });
+
+  it('emits empty classes for unknown helpers (be conservative)', () => {
+    const opening = parseOpening(
+      '<div className={mysteryHelper("p-4", "bg-blue-500")} />',
+    );
+
+    const result = extractClassNameFromJSX(opening);
+
+    // We don't know mysteryHelper's semantics — better to emit nothing
+    // than to mislead the agent with false-positive tokens.
+    expect(result?.classes).toEqual([]);
+    expect(result?.className).toBeUndefined();
+  });
+
+  it('walks member-expression helpers like utils.cn(...)', () => {
+    const opening = parseOpening(
+      '<div className={utils.cn("p-4", "bg-blue-500")} />',
+    );
+
+    expect(extractClassNameFromJSX(opening)?.classes).toEqual([
+      'p-4',
+      'bg-blue-500',
+    ]);
+  });
+});
+
+describe('extractClassNameFromJSX — conditional & logical', () => {
+  it('walks ternary expressions', () => {
+    const opening = parseOpening(
+      '<div className={isActive ? "bg-blue-500" : "bg-gray-200"} />',
+    );
+
+    const result = extractClassNameFromJSX(opening);
+
+    expect(result?.classes).toEqual(['bg-blue-500', 'bg-gray-200']);
+    expect(result?.className).toBeUndefined();
+  });
+
+  it('walks logical && expressions', () => {
+    const opening = parseOpening(
+      '<div className={isActive && "bg-blue-500"} />',
+    );
+
+    expect(extractClassNameFromJSX(opening)?.classes).toEqual(['bg-blue-500']);
+  });
+
+  it('walks logical || / ?? expressions', () => {
+    const orOpening = parseOpening(
+      '<div className={fallback || "bg-blue-500"} />',
+    );
+    const coalesceOpening = parseOpening(
+      '<div className={fallback ?? "bg-blue-500"} />',
+    );
+
+    expect(extractClassNameFromJSX(orOpening)?.classes).toEqual([
+      'bg-blue-500',
+    ]);
+    expect(extractClassNameFromJSX(coalesceOpening)?.classes).toEqual([
+      'bg-blue-500',
+    ]);
+  });
+});
+
+describe('extractClassNameFromJSX — fully computed / spread', () => {
+  it('returns empty classes for a bare identifier (variable ref)', () => {
+    const opening = parseOpening('<div className={dynamic} />');
+
+    const result = extractClassNameFromJSX(opening);
+
+    expect(result?.classes).toEqual([]);
+    expect(result?.className).toBeUndefined();
+  });
+
+  it('returns undefined when only spread attributes are present', () => {
+    const opening = parseOpening('<div {...props} />');
+
+    // Spread carries no className info we can extract statically.
+    expect(extractClassNameFromJSX(opening)).toBeUndefined();
+  });
+
+  it('still extracts className when both spread and className are present', () => {
+    const opening = parseOpening(
+      '<div {...props} className="p-4 bg-blue-500" />',
+    );
+
+    expect(extractClassNameFromJSX(opening)?.classes).toEqual([
+      'p-4',
+      'bg-blue-500',
+    ]);
+  });
+});
+
+describe('collectCssInJsDeclarations', () => {
+  function parseModule(source: string) {
+    return parse(source, {
+      sourceType: 'module',
+      plugins: ['typescript', 'jsx'],
+      ranges: true,
+    });
+  }
+
+  it('records `const X = styled.div`...`` declarations with library hint', () => {
+    const source = [
+      "import styled from 'styled-components';",
+      'const Card = styled.div`',
+      '  padding: 1rem;',
+      '  background: white;',
+      '`;',
+    ].join('\n');
+
+    const ast = parseModule(source);
+    const map = collectCssInJsDeclarations(ast, source, '/src/Card.tsx');
+
+    expect(map.size).toBe(1);
+    const entry = map.get('Card');
+    expect(entry).toBeDefined();
+    expect(entry?.kind).toBe('styled-tag');
+    expect(entry?.library).toBe('styled-components');
+    expect(entry?.file).toBe('/src/Card.tsx');
+    expect(entry?.line).toBe(2);
+    expect(entry?.blockText).toContain('padding: 1rem');
+  });
+
+  it('records `const X = styled(Component)`...`` (styled-call)', () => {
+    const source = [
+      "import styled from '@emotion/styled';",
+      'const FancyBox = styled(BaseBox)`',
+      '  color: rebeccapurple;',
+      '`;',
+    ].join('\n');
+
+    const ast = parseModule(source);
+    const map = collectCssInJsDeclarations(ast, source, '/src/FancyBox.tsx');
+
+    expect(map.get('FancyBox')?.kind).toBe('styled-call');
+    expect(map.get('FancyBox')?.library).toBe('emotion');
+  });
+
+  it('records `const X = css`...`` (emotion css-template)', () => {
+    const source = [
+      "import { css } from '@emotion/react';",
+      'const heading = css`font-size: 32px;`;',
+    ].join('\n');
+
+    const ast = parseModule(source);
+    const map = collectCssInJsDeclarations(ast, source, '/src/heading.ts');
+
+    expect(map.get('heading')?.kind).toBe('css-template');
+    expect(map.get('heading')?.library).toBe('emotion');
+  });
+
+  it('walks export declarations as well as bare const', () => {
+    const source = [
+      "import styled from 'styled-components';",
+      'export const Section = styled.section`padding: 2rem;`;',
+    ].join('\n');
+
+    const ast = parseModule(source);
+    const map = collectCssInJsDeclarations(ast, source, '/src/Section.tsx');
+
+    expect(map.has('Section')).toBe(true);
+  });
+
+  it('ignores non-styled tagged template expressions', () => {
+    const source = [
+      'const sql = (strings, ...values) => null;',
+      'const q = sql`SELECT 1`;',
+    ].join('\n');
+
+    const ast = parseModule(source);
+    const map = collectCssInJsDeclarations(ast, source, '/src/db.ts');
+
+    expect(map.size).toBe(0);
+  });
+
+  it('truncates large blockText to the per-element budget', () => {
+    const filler = 'a'.repeat(5 * 1024); // exceeds the 4 KB cap
+    const source = [
+      "import styled from 'styled-components';",
+      `const Huge = styled.div\`${filler}\`;`,
+    ].join('\n');
+
+    const ast = parseModule(source);
+    const map = collectCssInJsDeclarations(ast, source, '/src/Huge.tsx');
+
+    const text = map.get('Huge')?.blockText ?? '';
+    expect(text.length).toBeLessThanOrEqual(4 * 1024);
+  });
+});
+
+describe('resolveTagToBindingName', () => {
+  it('returns the tag itself for simple identifiers', () => {
+    expect(resolveTagToBindingName('Button')).toBe('Button');
+  });
+
+  it('returns the root identifier for member-expression tags', () => {
+    expect(resolveTagToBindingName('UI.Button.Primary')).toBe('UI');
+  });
+});

--- a/packages/domscribe-transform/tsconfig.spec.json
+++ b/packages/domscribe-transform/tsconfig.spec.json
@@ -26,7 +26,11 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "test/**/*.test.ts",
+    "test/**/*.spec.ts",
+    "test/**/*.test.tsx",
+    "test/**/*.spec.tsx"
   ],
   "references": [
     {

--- a/packages/domscribe-transform/vite.config.ts
+++ b/packages/domscribe-transform/vite.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
     watch: false,
     globals: true,
     environment: 'node',
-    include: ['src/**/*.{test,spec,bench}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    include: [
+      'src/**/*.{test,spec,bench}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+      'test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
+    ],
     reporters: ['default'],
     outputFile: './test-output/vitest/report.json',
     coverage: {


### PR DESCRIPTION
## Summary

Lands the build-time half of [RFC 0001: Component-Style Capture](../blob/rfc-0001-styles-buildtime/docs/rfcs/0001-component-styles-capture.md) (sprint 2734, Task A).

- `@domscribe/core`: adds optional `StyleSource` on `ManifestEntry` (className + parsed utility tokens + CSS-in-JS source-block location) and optional `ComponentStyles` on `RuntimeContextSchema` (≤32-property computed allowlist + resolved CSS custom properties). Bumps `ANNOTATION_SCHEMA_VERSION` from 1 → 2 with a purely-additive v1 → v2 migration step + tests for forward-compat with v1-pinned clients.
- `@domscribe/transform`: parser-agnostic style extractor wired into the existing JSX AST visit. Handles className literals, no-interpolation template literals, `clsx` / `cn` / `classNames` / `tw` / `twMerge` / `cva` calls, conditional/logical/array/object expressions, member-expression helpers, and bare-identifier spread. Scans top-level `styled.foo` / `styled(X)` / emotion `css` declarations to link JSX tags to their source blocks (block text capped at 4 KB, no theme resolution). Behind a new `captureStyles` feature flag (default off in v0.x per RFC reversibility plan); plumbed through Vite, webpack, and turbopack plugins.
- `@domscribe/relay`: `manifest.query` returns `styleSource` automatically (schema-driven); `resolve` extracts and forwards it explicitly. Tool descriptions updated so agents know they can request static styling context before reaching for runtime data.

The runtime half (`StyleCapturer` populating `componentStyles`, MCP `query.bySource` extension, test-fixtures falsifier harness) is Task B (#49) and depends on the schema additions in this PR.

## Test plan

- [x] `nx run domscribe-core:test` — 122 tests pass (incl. 3 new migration cases).
- [x] `nx run domscribe-transform:test` — 405 tests pass (incl. 33 new corpus cases under `test/className-corpus/` + 7 new injector integration cases for `captureStyles: true`).
- [x] `nx run domscribe-relay:test` — 306 tests pass (incl. new `resolve.tool` forward-the-styleSource case; updated `file-annotation-storage` specs to reference `ANNOTATION_SCHEMA_VERSION` instead of hard-coding 1).
- [x] `nx run-many -t test --exclude domscribe-test-fixtures` — all 10 projects pass.
- [x] `nx run-many -t lint -p domscribe-core,domscribe-transform,domscribe-relay` — clean.
- [x] `nx run-many -t build --exclude domscribe-test-fixtures` — all 12 projects build.
- [ ] **Falsifier coverage** — measuring the ≥70% one-shot styling-completion rate requires the test-fixtures harness shipping in Task B (#49); the build-time side cannot self-certify it.

## Out of scope

Explicitly deferred per DOP / PM plan: Svelte adapter, post-completion visual-diff loop, props/state hardening, RCP-as-public-protocol revival, vendor directory, per-adapter (React/Vue/Next/Nuxt) styling work, transform-time Tailwind/theme resolution.

## Schema-bump risk

`ANNOTATION_SCHEMA_VERSION` 1 → 2 is additive only. V1-pinned consumers reading v2 annotations see the v1 fields untouched (the new `componentStyles` slot is absent). On-disk v1 annotations migrate forward through `FileAnnotationStorage.read` / `listByStatus` (existing migrate-on-read path) without re-validation. Asserted by `annotation-migrations.spec.ts` and `file-annotation-storage.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)